### PR TITLE
feat: add `cursor_text_color`

### DIFF
--- a/templates/base16-256.mustache
+++ b/templates/base16-256.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}

--- a/templates/base24-256.mustache
+++ b/templates/base24-256.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}


### PR DESCRIPTION
Cherry-pick of:

- https://github.com/kdrag0n/base16-kitty/pull/12

from the "original" [base16-kitty repo](https://github.com/kdrag0n/base16-kitty) (ie. the one [referenced](https://github.com/chriskempson/base16-templates-source/blob/394b12c904fa5d0b8cf458639877dcc484520194/list.yaml#L38) from [chriskempson/base16-templates-source](https://github.com/chriskempson/base16-templates-source)).

Original description:

> By default, Kitty is setting the cursor text color to `#111111`.
>
> See https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.cursor_text_color.
>
> It's not rendering well when using vim with light theme.
>
> ![348778491-776f0881-fcf1-4e0b-8ff9-480cf32b3a2c](https://github.com/user-attachments/assets/4d6c6e86-32bc-4c1f-a039-9b3b03154cee)
