### PR TITLE
Update templates to reflect styling spec and deprecate 256 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,8 @@ Note that kitty will need to be restarted for the change to take effect.
 
 ## 256-color variants
 
-The 256-color variants are for those who wish to use the 16 ANSI colors while
-retaining accuracy for bright color variants. For the Base16 color
-themes, this is achieved by making the bright variants mirror their
-regular counterparts instead of attempting to map them to other Base16
-colors. Base24 supports brighter colors.
-
-**TL;DR**: If some colors look strange or darker than normal, try the
-256-color variant of your scheme of choice.
+These are deprecated themes, use `./colors/*.conf` instead. At some
+point `./colors-256/*.conf` will be removed from the repository.
 
 [Tinted Theming]: https://github.com/tinted-theming
 [kitty]: https://github.com/kovidgoyal/kitty

--- a/templates/base16-256-deprecated.mustache
+++ b/templates/base16-256-deprecated.mustache
@@ -1,9 +1,11 @@
-# {{scheme-system}} {{scheme-name}} - kitty color config
-# Scheme by {{scheme-author}}
+# Scheme name: {{scheme-system}} {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
+
 background #{{base00-hex}}
 foreground #{{base05-hex}}
-selection_background #{{base05-hex}}
-selection_foreground #{{base00-hex}}
+selection_background #{{base03-hex}}
+selection_foreground #{{base05-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
 cursor_text_color #{{base00-hex}}
@@ -28,7 +30,7 @@ color6 #{{base0C-hex}}
 color7 #{{base05-hex}}
 
 # bright
-color8 #{{base03-hex}}
+color8 #{{base02-hex}}
 color9 #{{base08-hex}}
 color10 #{{base0B-hex}}
 color11 #{{base0A-hex}}

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,9 +1,11 @@
-# {{scheme-system}} {{scheme-name}} - kitty color config
-# Scheme by {{scheme-author}}
+# Scheme name: {{scheme-system}} {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
+
 background #{{base00-hex}}
 foreground #{{base05-hex}}
-selection_background #{{base05-hex}}
-selection_foreground #{{base00-hex}}
+selection_background #{{base03-hex}}
+selection_foreground #{{base05-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
 cursor_text_color #{{base00-hex}}
@@ -28,11 +30,19 @@ color6 #{{base0C-hex}}
 color7 #{{base05-hex}}
 
 # bright
-color8 #{{base03-hex}}
-color9 #{{base09-hex}}
-color10 #{{base01-hex}}
-color11 #{{base02-hex}}
-color12 #{{base04-hex}}
-color13 #{{base06-hex}}
-color14 #{{base0F-hex}}
+color8 #{{base02-hex}}
+color9 #{{base08-hex}}
+color10 #{{base0B-hex}}
+color11 #{{base0A-hex}}
+color12 #{{base0D-hex}}
+color13 #{{base0E-hex}}
+color14 #{{base0C-hex}}
 color15 #{{base07-hex}}
+
+# extended base16 colors
+color16 #{{base09-hex}}
+color17 #{{base0F-hex}}
+color18 #{{base01-hex}}
+color19 #{{base02-hex}}
+color20 #{{base04-hex}}
+color21 #{{base06-hex}}

--- a/templates/base24-256-deprecated.mustache
+++ b/templates/base24-256-deprecated.mustache
@@ -1,5 +1,7 @@
-# {{scheme-system}} {{scheme-name}} - kitty color config
-# Scheme by {{scheme-author}}
+# Scheme name: {{scheme-system}} {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
+
 background #{{base00-hex}}
 foreground #{{base05-hex}}
 selection_background #{{base05-hex}}
@@ -28,7 +30,7 @@ color6 #{{base0C-hex}}
 color7 #{{base05-hex}}
 
 # bright
-color8 #{{base03-hex}}
+color8 #{{base02-hex}}
 color9 #{{base12-hex}}
 color10 #{{base14-hex}}
 color11 #{{base13-hex}}

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,5 +1,7 @@
-# {{scheme-system}} {{scheme-name}} - kitty color config
-# Scheme by {{scheme-author}}
+# Scheme name: {{scheme-system}} {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
+
 background #{{base00-hex}}
 foreground #{{base05-hex}}
 selection_background #{{base05-hex}}
@@ -28,7 +30,7 @@ color6 #{{base0C-hex}}
 color7 #{{base05-hex}}
 
 # bright
-color8 #{{base03-hex}}
+color8 #{{base02-hex}}
 color9 #{{base12-hex}}
 color10 #{{base14-hex}}
 color11 #{{base13-hex}}
@@ -36,3 +38,11 @@ color12 #{{base16-hex}}
 color13 #{{base17-hex}}
 color14 #{{base15-hex}}
 color15 #{{base07-hex}}
+
+# extended base16 colors
+color16 #{{base09-hex}}
+color17 #{{base0F-hex}}
+color18 #{{base01-hex}}
+color19 #{{base02-hex}}
+color20 #{{base04-hex}}
+color21 #{{base06-hex}}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -2,15 +2,19 @@ base16:
   extension: .conf
   output: colors
   supported-systems: [base16]
-base16-256:
-  extension: .conf
-  output: colors-256
-  supported-systems: [base16]
+
 base24:
   extension: .conf
   output: colors
   supported-systems: [base24]
-base24-256:
+
+# Deprecated templates
+base16-256-deprecated:
+  extension: .conf
+  output: colors-256
+  supported-systems: [base16]
+
+base24-256-deprecated:
   extension: .conf
   output: colors-256
   supported-systems: [base24]


### PR DESCRIPTION
The 256 variants are outdated and don't follow the styling spec at all. They use greyscale colours for bright variants where we should be reusing the colors for bright and non-bright variants as per [the styling spec](https://github.com/tinted-theming/home/blob/main/styling.md).

This PR:

- Deprecates the 256 templates
- Adds extended colours
- Fixes the styling as per tinted-theming styling spec