### PR TITLE
Update templates to match kitty theme template

### DIFF
--- a/colors/base16-3024.conf
+++ b/colors/base16-3024.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 3024
+## author:   Jan T. Sott (http://github.com/idleberg)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    3024
+
 # Scheme name: base16 3024
 # Scheme author: Jan T. Sott (http://github.com/idleberg)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #090300
 foreground #a5a2a2
 selection_background #5c5855
 selection_foreground #a5a2a2
-url_color #807d7c
+
+# Cursor colors
 cursor #a5a2a2
 cursor_text_color #090300
+
+# URL underline color when hovering with mouse
+url_color #807d7c
+
+# Kitty window border colors
 active_border_color #5c5855
 inactive_border_color #3a3432
+
+# OS Window titlebar colors
+wayland_titlebar_color #090300
+macos_titlebar_color #090300
+
+# Tab bar colors
 active_tab_background #090300
 active_tab_foreground #a5a2a2
 inactive_tab_background #3a3432
 inactive_tab_foreground #807d7c
 tab_bar_background #3a3432
-wayland_titlebar_color #090300
-macos_titlebar_color #090300
 
+# The 16 terminal colors
 # normal
 color0 #090300
 color1 #db2d20

--- a/colors/base16-apathy.conf
+++ b/colors/base16-apathy.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Apathy
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Apathy
+
 # Scheme name: base16 Apathy
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #031a16
 foreground #81b5ac
 selection_background #2b685e
 selection_foreground #81b5ac
-url_color #5f9c92
+
+# Cursor colors
 cursor #81b5ac
 cursor_text_color #031a16
+
+# URL underline color when hovering with mouse
+url_color #5f9c92
+
+# Kitty window border colors
 active_border_color #2b685e
 inactive_border_color #0b342d
+
+# OS Window titlebar colors
+wayland_titlebar_color #031a16
+macos_titlebar_color #031a16
+
+# Tab bar colors
 active_tab_background #031a16
 active_tab_foreground #81b5ac
 inactive_tab_background #0b342d
 inactive_tab_foreground #5f9c92
 tab_bar_background #0b342d
-wayland_titlebar_color #031a16
-macos_titlebar_color #031a16
 
+# The 16 terminal colors
 # normal
 color0 #031a16
 color1 #3e9688

--- a/colors/base16-apprentice.conf
+++ b/colors/base16-apprentice.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Apprentice
+## author:   romainl
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Apprentice
+
 # Scheme name: base16 Apprentice
 # Scheme author: romainl
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #262626
 foreground #5f5f87
 selection_background #87875f
 selection_foreground #5f5f87
-url_color #5f87af
+
+# Cursor colors
 cursor #5f5f87
 cursor_text_color #262626
+
+# URL underline color when hovering with mouse
+url_color #5f87af
+
+# Kitty window border colors
 active_border_color #87875f
 inactive_border_color #af5f5f
+
+# OS Window titlebar colors
+wayland_titlebar_color #262626
+macos_titlebar_color #262626
+
+# Tab bar colors
 active_tab_background #262626
 active_tab_foreground #5f5f87
 inactive_tab_background #af5f5f
 inactive_tab_foreground #5f87af
 tab_bar_background #af5f5f
-wayland_titlebar_color #262626
-macos_titlebar_color #262626
 
+# The 16 terminal colors
 # normal
 color0 #262626
 color1 #444444

--- a/colors/base16-ashes.conf
+++ b/colors/base16-ashes.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Ashes
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Ashes
+
 # Scheme name: base16 Ashes
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c2023
 foreground #c7ccd1
 selection_background #747c84
 selection_foreground #c7ccd1
-url_color #adb3ba
+
+# Cursor colors
 cursor #c7ccd1
 cursor_text_color #1c2023
+
+# URL underline color when hovering with mouse
+url_color #adb3ba
+
+# Kitty window border colors
 active_border_color #747c84
 inactive_border_color #393f45
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c2023
+macos_titlebar_color #1c2023
+
+# Tab bar colors
 active_tab_background #1c2023
 active_tab_foreground #c7ccd1
 inactive_tab_background #393f45
 inactive_tab_foreground #adb3ba
 tab_bar_background #393f45
-wayland_titlebar_color #1c2023
-macos_titlebar_color #1c2023
 
+# The 16 terminal colors
 # normal
 color0 #1c2023
 color1 #c7ae95

--- a/colors/base16-atelier-cave-light.conf
+++ b/colors/base16-atelier-cave-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Cave Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Cave Light
+
 # Scheme name: base16 Atelier Cave Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #efecf4
 foreground #585260
 selection_background #7e7887
 selection_foreground #585260
-url_color #655f6d
+
+# Cursor colors
 cursor #585260
 cursor_text_color #efecf4
+
+# URL underline color when hovering with mouse
+url_color #655f6d
+
+# Kitty window border colors
 active_border_color #7e7887
 inactive_border_color #e2dfe7
+
+# OS Window titlebar colors
+wayland_titlebar_color #efecf4
+macos_titlebar_color #efecf4
+
+# Tab bar colors
 active_tab_background #efecf4
 active_tab_foreground #585260
 inactive_tab_background #e2dfe7
 inactive_tab_foreground #655f6d
 tab_bar_background #e2dfe7
-wayland_titlebar_color #efecf4
-macos_titlebar_color #efecf4
 
+# The 16 terminal colors
 # normal
 color0 #efecf4
 color1 #be4678

--- a/colors/base16-atelier-cave.conf
+++ b/colors/base16-atelier-cave.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Cave
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Cave
+
 # Scheme name: base16 Atelier Cave
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #19171c
 foreground #8b8792
 selection_background #655f6d
 selection_foreground #8b8792
-url_color #7e7887
+
+# Cursor colors
 cursor #8b8792
 cursor_text_color #19171c
+
+# URL underline color when hovering with mouse
+url_color #7e7887
+
+# Kitty window border colors
 active_border_color #655f6d
 inactive_border_color #26232a
+
+# OS Window titlebar colors
+wayland_titlebar_color #19171c
+macos_titlebar_color #19171c
+
+# Tab bar colors
 active_tab_background #19171c
 active_tab_foreground #8b8792
 inactive_tab_background #26232a
 inactive_tab_foreground #7e7887
 tab_bar_background #26232a
-wayland_titlebar_color #19171c
-macos_titlebar_color #19171c
 
+# The 16 terminal colors
 # normal
 color0 #19171c
 color1 #be4678

--- a/colors/base16-atelier-dune-light.conf
+++ b/colors/base16-atelier-dune-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Dune Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Dune Light
+
 # Scheme name: base16 Atelier Dune Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fefbec
 foreground #6e6b5e
 selection_background #999580
 selection_foreground #6e6b5e
-url_color #7d7a68
+
+# Cursor colors
 cursor #6e6b5e
 cursor_text_color #fefbec
+
+# URL underline color when hovering with mouse
+url_color #7d7a68
+
+# Kitty window border colors
 active_border_color #999580
 inactive_border_color #e8e4cf
+
+# OS Window titlebar colors
+wayland_titlebar_color #fefbec
+macos_titlebar_color #fefbec
+
+# Tab bar colors
 active_tab_background #fefbec
 active_tab_foreground #6e6b5e
 inactive_tab_background #e8e4cf
 inactive_tab_foreground #7d7a68
 tab_bar_background #e8e4cf
-wayland_titlebar_color #fefbec
-macos_titlebar_color #fefbec
 
+# The 16 terminal colors
 # normal
 color0 #fefbec
 color1 #d73737

--- a/colors/base16-atelier-dune.conf
+++ b/colors/base16-atelier-dune.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Dune
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Dune
+
 # Scheme name: base16 Atelier Dune
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #20201d
 foreground #a6a28c
 selection_background #7d7a68
 selection_foreground #a6a28c
-url_color #999580
+
+# Cursor colors
 cursor #a6a28c
 cursor_text_color #20201d
+
+# URL underline color when hovering with mouse
+url_color #999580
+
+# Kitty window border colors
 active_border_color #7d7a68
 inactive_border_color #292824
+
+# OS Window titlebar colors
+wayland_titlebar_color #20201d
+macos_titlebar_color #20201d
+
+# Tab bar colors
 active_tab_background #20201d
 active_tab_foreground #a6a28c
 inactive_tab_background #292824
 inactive_tab_foreground #999580
 tab_bar_background #292824
-wayland_titlebar_color #20201d
-macos_titlebar_color #20201d
 
+# The 16 terminal colors
 # normal
 color0 #20201d
 color1 #d73737

--- a/colors/base16-atelier-estuary-light.conf
+++ b/colors/base16-atelier-estuary-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Estuary Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Estuary Light
+
 # Scheme name: base16 Atelier Estuary Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f4f3ec
 foreground #5f5e4e
 selection_background #878573
 selection_foreground #5f5e4e
-url_color #6c6b5a
+
+# Cursor colors
 cursor #5f5e4e
 cursor_text_color #f4f3ec
+
+# URL underline color when hovering with mouse
+url_color #6c6b5a
+
+# Kitty window border colors
 active_border_color #878573
 inactive_border_color #e7e6df
+
+# OS Window titlebar colors
+wayland_titlebar_color #f4f3ec
+macos_titlebar_color #f4f3ec
+
+# Tab bar colors
 active_tab_background #f4f3ec
 active_tab_foreground #5f5e4e
 inactive_tab_background #e7e6df
 inactive_tab_foreground #6c6b5a
 tab_bar_background #e7e6df
-wayland_titlebar_color #f4f3ec
-macos_titlebar_color #f4f3ec
 
+# The 16 terminal colors
 # normal
 color0 #f4f3ec
 color1 #ba6236

--- a/colors/base16-atelier-estuary.conf
+++ b/colors/base16-atelier-estuary.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Estuary
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Estuary
+
 # Scheme name: base16 Atelier Estuary
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #22221b
 foreground #929181
 selection_background #6c6b5a
 selection_foreground #929181
-url_color #878573
+
+# Cursor colors
 cursor #929181
 cursor_text_color #22221b
+
+# URL underline color when hovering with mouse
+url_color #878573
+
+# Kitty window border colors
 active_border_color #6c6b5a
 inactive_border_color #302f27
+
+# OS Window titlebar colors
+wayland_titlebar_color #22221b
+macos_titlebar_color #22221b
+
+# Tab bar colors
 active_tab_background #22221b
 active_tab_foreground #929181
 inactive_tab_background #302f27
 inactive_tab_foreground #878573
 tab_bar_background #302f27
-wayland_titlebar_color #22221b
-macos_titlebar_color #22221b
 
+# The 16 terminal colors
 # normal
 color0 #22221b
 color1 #ba6236

--- a/colors/base16-atelier-forest-light.conf
+++ b/colors/base16-atelier-forest-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Forest Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Forest Light
+
 # Scheme name: base16 Atelier Forest Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f1efee
 foreground #68615e
 selection_background #9c9491
 selection_foreground #68615e
-url_color #766e6b
+
+# Cursor colors
 cursor #68615e
 cursor_text_color #f1efee
+
+# URL underline color when hovering with mouse
+url_color #766e6b
+
+# Kitty window border colors
 active_border_color #9c9491
 inactive_border_color #e6e2e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #f1efee
+macos_titlebar_color #f1efee
+
+# Tab bar colors
 active_tab_background #f1efee
 active_tab_foreground #68615e
 inactive_tab_background #e6e2e0
 inactive_tab_foreground #766e6b
 tab_bar_background #e6e2e0
-wayland_titlebar_color #f1efee
-macos_titlebar_color #f1efee
 
+# The 16 terminal colors
 # normal
 color0 #f1efee
 color1 #f22c40

--- a/colors/base16-atelier-forest.conf
+++ b/colors/base16-atelier-forest.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Forest
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Forest
+
 # Scheme name: base16 Atelier Forest
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1b1918
 foreground #a8a19f
 selection_background #766e6b
 selection_foreground #a8a19f
-url_color #9c9491
+
+# Cursor colors
 cursor #a8a19f
 cursor_text_color #1b1918
+
+# URL underline color when hovering with mouse
+url_color #9c9491
+
+# Kitty window border colors
 active_border_color #766e6b
 inactive_border_color #2c2421
+
+# OS Window titlebar colors
+wayland_titlebar_color #1b1918
+macos_titlebar_color #1b1918
+
+# Tab bar colors
 active_tab_background #1b1918
 active_tab_foreground #a8a19f
 inactive_tab_background #2c2421
 inactive_tab_foreground #9c9491
 tab_bar_background #2c2421
-wayland_titlebar_color #1b1918
-macos_titlebar_color #1b1918
 
+# The 16 terminal colors
 # normal
 color0 #1b1918
 color1 #f22c40

--- a/colors/base16-atelier-heath-light.conf
+++ b/colors/base16-atelier-heath-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Heath Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Heath Light
+
 # Scheme name: base16 Atelier Heath Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f7f3f7
 foreground #695d69
 selection_background #9e8f9e
 selection_foreground #695d69
-url_color #776977
+
+# Cursor colors
 cursor #695d69
 cursor_text_color #f7f3f7
+
+# URL underline color when hovering with mouse
+url_color #776977
+
+# Kitty window border colors
 active_border_color #9e8f9e
 inactive_border_color #d8cad8
+
+# OS Window titlebar colors
+wayland_titlebar_color #f7f3f7
+macos_titlebar_color #f7f3f7
+
+# Tab bar colors
 active_tab_background #f7f3f7
 active_tab_foreground #695d69
 inactive_tab_background #d8cad8
 inactive_tab_foreground #776977
 tab_bar_background #d8cad8
-wayland_titlebar_color #f7f3f7
-macos_titlebar_color #f7f3f7
 
+# The 16 terminal colors
 # normal
 color0 #f7f3f7
 color1 #ca402b

--- a/colors/base16-atelier-heath.conf
+++ b/colors/base16-atelier-heath.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Heath
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Heath
+
 # Scheme name: base16 Atelier Heath
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1b181b
 foreground #ab9bab
 selection_background #776977
 selection_foreground #ab9bab
-url_color #9e8f9e
+
+# Cursor colors
 cursor #ab9bab
 cursor_text_color #1b181b
+
+# URL underline color when hovering with mouse
+url_color #9e8f9e
+
+# Kitty window border colors
 active_border_color #776977
 inactive_border_color #292329
+
+# OS Window titlebar colors
+wayland_titlebar_color #1b181b
+macos_titlebar_color #1b181b
+
+# Tab bar colors
 active_tab_background #1b181b
 active_tab_foreground #ab9bab
 inactive_tab_background #292329
 inactive_tab_foreground #9e8f9e
 tab_bar_background #292329
-wayland_titlebar_color #1b181b
-macos_titlebar_color #1b181b
 
+# The 16 terminal colors
 # normal
 color0 #1b181b
 color1 #ca402b

--- a/colors/base16-atelier-lakeside-light.conf
+++ b/colors/base16-atelier-lakeside-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Lakeside Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Lakeside Light
+
 # Scheme name: base16 Atelier Lakeside Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ebf8ff
 foreground #516d7b
 selection_background #7195a8
 selection_foreground #516d7b
-url_color #5a7b8c
+
+# Cursor colors
 cursor #516d7b
 cursor_text_color #ebf8ff
+
+# URL underline color when hovering with mouse
+url_color #5a7b8c
+
+# Kitty window border colors
 active_border_color #7195a8
 inactive_border_color #c1e4f6
+
+# OS Window titlebar colors
+wayland_titlebar_color #ebf8ff
+macos_titlebar_color #ebf8ff
+
+# Tab bar colors
 active_tab_background #ebf8ff
 active_tab_foreground #516d7b
 inactive_tab_background #c1e4f6
 inactive_tab_foreground #5a7b8c
 tab_bar_background #c1e4f6
-wayland_titlebar_color #ebf8ff
-macos_titlebar_color #ebf8ff
 
+# The 16 terminal colors
 # normal
 color0 #ebf8ff
 color1 #d22d72

--- a/colors/base16-atelier-lakeside.conf
+++ b/colors/base16-atelier-lakeside.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Lakeside
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Lakeside
+
 # Scheme name: base16 Atelier Lakeside
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #161b1d
 foreground #7ea2b4
 selection_background #5a7b8c
 selection_foreground #7ea2b4
-url_color #7195a8
+
+# Cursor colors
 cursor #7ea2b4
 cursor_text_color #161b1d
+
+# URL underline color when hovering with mouse
+url_color #7195a8
+
+# Kitty window border colors
 active_border_color #5a7b8c
 inactive_border_color #1f292e
+
+# OS Window titlebar colors
+wayland_titlebar_color #161b1d
+macos_titlebar_color #161b1d
+
+# Tab bar colors
 active_tab_background #161b1d
 active_tab_foreground #7ea2b4
 inactive_tab_background #1f292e
 inactive_tab_foreground #7195a8
 tab_bar_background #1f292e
-wayland_titlebar_color #161b1d
-macos_titlebar_color #161b1d
 
+# The 16 terminal colors
 # normal
 color0 #161b1d
 color1 #d22d72

--- a/colors/base16-atelier-plateau-light.conf
+++ b/colors/base16-atelier-plateau-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Plateau Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Plateau Light
+
 # Scheme name: base16 Atelier Plateau Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f4ecec
 foreground #585050
 selection_background #7e7777
 selection_foreground #585050
-url_color #655d5d
+
+# Cursor colors
 cursor #585050
 cursor_text_color #f4ecec
+
+# URL underline color when hovering with mouse
+url_color #655d5d
+
+# Kitty window border colors
 active_border_color #7e7777
 inactive_border_color #e7dfdf
+
+# OS Window titlebar colors
+wayland_titlebar_color #f4ecec
+macos_titlebar_color #f4ecec
+
+# Tab bar colors
 active_tab_background #f4ecec
 active_tab_foreground #585050
 inactive_tab_background #e7dfdf
 inactive_tab_foreground #655d5d
 tab_bar_background #e7dfdf
-wayland_titlebar_color #f4ecec
-macos_titlebar_color #f4ecec
 
+# The 16 terminal colors
 # normal
 color0 #f4ecec
 color1 #ca4949

--- a/colors/base16-atelier-plateau.conf
+++ b/colors/base16-atelier-plateau.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Plateau
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Plateau
+
 # Scheme name: base16 Atelier Plateau
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1b1818
 foreground #8a8585
 selection_background #655d5d
 selection_foreground #8a8585
-url_color #7e7777
+
+# Cursor colors
 cursor #8a8585
 cursor_text_color #1b1818
+
+# URL underline color when hovering with mouse
+url_color #7e7777
+
+# Kitty window border colors
 active_border_color #655d5d
 inactive_border_color #292424
+
+# OS Window titlebar colors
+wayland_titlebar_color #1b1818
+macos_titlebar_color #1b1818
+
+# Tab bar colors
 active_tab_background #1b1818
 active_tab_foreground #8a8585
 inactive_tab_background #292424
 inactive_tab_foreground #7e7777
 tab_bar_background #292424
-wayland_titlebar_color #1b1818
-macos_titlebar_color #1b1818
 
+# The 16 terminal colors
 # normal
 color0 #1b1818
 color1 #ca4949

--- a/colors/base16-atelier-savanna-light.conf
+++ b/colors/base16-atelier-savanna-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Savanna Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Savanna Light
+
 # Scheme name: base16 Atelier Savanna Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ecf4ee
 foreground #526057
 selection_background #78877d
 selection_foreground #526057
-url_color #5f6d64
+
+# Cursor colors
 cursor #526057
 cursor_text_color #ecf4ee
+
+# URL underline color when hovering with mouse
+url_color #5f6d64
+
+# Kitty window border colors
 active_border_color #78877d
 inactive_border_color #dfe7e2
+
+# OS Window titlebar colors
+wayland_titlebar_color #ecf4ee
+macos_titlebar_color #ecf4ee
+
+# Tab bar colors
 active_tab_background #ecf4ee
 active_tab_foreground #526057
 inactive_tab_background #dfe7e2
 inactive_tab_foreground #5f6d64
 tab_bar_background #dfe7e2
-wayland_titlebar_color #ecf4ee
-macos_titlebar_color #ecf4ee
 
+# The 16 terminal colors
 # normal
 color0 #ecf4ee
 color1 #b16139

--- a/colors/base16-atelier-savanna.conf
+++ b/colors/base16-atelier-savanna.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Savanna
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Savanna
+
 # Scheme name: base16 Atelier Savanna
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171c19
 foreground #87928a
 selection_background #5f6d64
 selection_foreground #87928a
-url_color #78877d
+
+# Cursor colors
 cursor #87928a
 cursor_text_color #171c19
+
+# URL underline color when hovering with mouse
+url_color #78877d
+
+# Kitty window border colors
 active_border_color #5f6d64
 inactive_border_color #232a25
+
+# OS Window titlebar colors
+wayland_titlebar_color #171c19
+macos_titlebar_color #171c19
+
+# Tab bar colors
 active_tab_background #171c19
 active_tab_foreground #87928a
 inactive_tab_background #232a25
 inactive_tab_foreground #78877d
 tab_bar_background #232a25
-wayland_titlebar_color #171c19
-macos_titlebar_color #171c19
 
+# The 16 terminal colors
 # normal
 color0 #171c19
 color1 #b16139

--- a/colors/base16-atelier-seaside-light.conf
+++ b/colors/base16-atelier-seaside-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Seaside Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Seaside Light
+
 # Scheme name: base16 Atelier Seaside Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f4fbf4
 foreground #5e6e5e
 selection_background #809980
 selection_foreground #5e6e5e
-url_color #687d68
+
+# Cursor colors
 cursor #5e6e5e
 cursor_text_color #f4fbf4
+
+# URL underline color when hovering with mouse
+url_color #687d68
+
+# Kitty window border colors
 active_border_color #809980
 inactive_border_color #cfe8cf
+
+# OS Window titlebar colors
+wayland_titlebar_color #f4fbf4
+macos_titlebar_color #f4fbf4
+
+# Tab bar colors
 active_tab_background #f4fbf4
 active_tab_foreground #5e6e5e
 inactive_tab_background #cfe8cf
 inactive_tab_foreground #687d68
 tab_bar_background #cfe8cf
-wayland_titlebar_color #f4fbf4
-macos_titlebar_color #f4fbf4
 
+# The 16 terminal colors
 # normal
 color0 #f4fbf4
 color1 #e6193c

--- a/colors/base16-atelier-seaside.conf
+++ b/colors/base16-atelier-seaside.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Seaside
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Seaside
+
 # Scheme name: base16 Atelier Seaside
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #131513
 foreground #8ca68c
 selection_background #687d68
 selection_foreground #8ca68c
-url_color #809980
+
+# Cursor colors
 cursor #8ca68c
 cursor_text_color #131513
+
+# URL underline color when hovering with mouse
+url_color #809980
+
+# Kitty window border colors
 active_border_color #687d68
 inactive_border_color #242924
+
+# OS Window titlebar colors
+wayland_titlebar_color #131513
+macos_titlebar_color #131513
+
+# Tab bar colors
 active_tab_background #131513
 active_tab_foreground #8ca68c
 inactive_tab_background #242924
 inactive_tab_foreground #809980
 tab_bar_background #242924
-wayland_titlebar_color #131513
-macos_titlebar_color #131513
 
+# The 16 terminal colors
 # normal
 color0 #131513
 color1 #e6193c

--- a/colors/base16-atelier-sulphurpool-light.conf
+++ b/colors/base16-atelier-sulphurpool-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Sulphurpool Light
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Sulphurpool Light
+
 # Scheme name: base16 Atelier Sulphurpool Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f5f7ff
 foreground #5e6687
 selection_background #898ea4
 selection_foreground #5e6687
-url_color #6b7394
+
+# Cursor colors
 cursor #5e6687
 cursor_text_color #f5f7ff
+
+# URL underline color when hovering with mouse
+url_color #6b7394
+
+# Kitty window border colors
 active_border_color #898ea4
 inactive_border_color #dfe2f1
+
+# OS Window titlebar colors
+wayland_titlebar_color #f5f7ff
+macos_titlebar_color #f5f7ff
+
+# Tab bar colors
 active_tab_background #f5f7ff
 active_tab_foreground #5e6687
 inactive_tab_background #dfe2f1
 inactive_tab_foreground #6b7394
 tab_bar_background #dfe2f1
-wayland_titlebar_color #f5f7ff
-macos_titlebar_color #f5f7ff
 
+# The 16 terminal colors
 # normal
 color0 #f5f7ff
 color1 #c94922

--- a/colors/base16-atelier-sulphurpool.conf
+++ b/colors/base16-atelier-sulphurpool.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atelier Sulphurpool
+## author:   Bram de Haan (http://atelierbramdehaan.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atelier Sulphurpool
+
 # Scheme name: base16 Atelier Sulphurpool
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #202746
 foreground #979db4
 selection_background #6b7394
 selection_foreground #979db4
-url_color #898ea4
+
+# Cursor colors
 cursor #979db4
 cursor_text_color #202746
+
+# URL underline color when hovering with mouse
+url_color #898ea4
+
+# Kitty window border colors
 active_border_color #6b7394
 inactive_border_color #293256
+
+# OS Window titlebar colors
+wayland_titlebar_color #202746
+macos_titlebar_color #202746
+
+# Tab bar colors
 active_tab_background #202746
 active_tab_foreground #979db4
 inactive_tab_background #293256
 inactive_tab_foreground #898ea4
 tab_bar_background #293256
-wayland_titlebar_color #202746
-macos_titlebar_color #202746
 
+# The 16 terminal colors
 # normal
 color0 #202746
 color1 #c94922

--- a/colors/base16-atlas.conf
+++ b/colors/base16-atlas.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Atlas
+## author:   Alex Lende (https://ajlende.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Atlas
+
 # Scheme name: base16 Atlas
 # Scheme author: Alex Lende (https://ajlende.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #002635
 foreground #a1a19a
 selection_background #6c8b91
 selection_foreground #a1a19a
-url_color #869696
+
+# Cursor colors
 cursor #a1a19a
 cursor_text_color #002635
+
+# URL underline color when hovering with mouse
+url_color #869696
+
+# Kitty window border colors
 active_border_color #6c8b91
 inactive_border_color #00384d
+
+# OS Window titlebar colors
+wayland_titlebar_color #002635
+macos_titlebar_color #002635
+
+# Tab bar colors
 active_tab_background #002635
 active_tab_foreground #a1a19a
 inactive_tab_background #00384d
 inactive_tab_foreground #869696
 tab_bar_background #00384d
-wayland_titlebar_color #002635
-macos_titlebar_color #002635
 
+# The 16 terminal colors
 # normal
 color0 #002635
 color1 #ff5a67

--- a/colors/base16-ayu-dark.conf
+++ b/colors/base16-ayu-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Ayu Dark
+## author:   Khue Nguyen &lt;Z5483Y@gmail.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Ayu Dark
+
 # Scheme name: base16 Ayu Dark
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0f1419
 foreground #e6e1cf
 selection_background #3e4b59
 selection_foreground #e6e1cf
-url_color #bfbdb6
+
+# Cursor colors
 cursor #e6e1cf
 cursor_text_color #0f1419
+
+# URL underline color when hovering with mouse
+url_color #bfbdb6
+
+# Kitty window border colors
 active_border_color #3e4b59
 inactive_border_color #131721
+
+# OS Window titlebar colors
+wayland_titlebar_color #0f1419
+macos_titlebar_color #0f1419
+
+# Tab bar colors
 active_tab_background #0f1419
 active_tab_foreground #e6e1cf
 inactive_tab_background #131721
 inactive_tab_foreground #bfbdb6
 tab_bar_background #131721
-wayland_titlebar_color #0f1419
-macos_titlebar_color #0f1419
 
+# The 16 terminal colors
 # normal
 color0 #0f1419
 color1 #f07178

--- a/colors/base16-ayu-light.conf
+++ b/colors/base16-ayu-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Ayu Light
+## author:   Khue Nguyen &lt;Z5483Y@gmail.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Ayu Light
+
 # Scheme name: base16 Ayu Light
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fafafa
 foreground #5c6773
 selection_background #abb0b6
 selection_foreground #5c6773
-url_color #828c99
+
+# Cursor colors
 cursor #5c6773
 cursor_text_color #fafafa
+
+# URL underline color when hovering with mouse
+url_color #828c99
+
+# Kitty window border colors
 active_border_color #abb0b6
 inactive_border_color #f3f4f5
+
+# OS Window titlebar colors
+wayland_titlebar_color #fafafa
+macos_titlebar_color #fafafa
+
+# Tab bar colors
 active_tab_background #fafafa
 active_tab_foreground #5c6773
 inactive_tab_background #f3f4f5
 inactive_tab_foreground #828c99
 tab_bar_background #f3f4f5
-wayland_titlebar_color #fafafa
-macos_titlebar_color #fafafa
 
+# The 16 terminal colors
 # normal
 color0 #fafafa
 color1 #f07178

--- a/colors/base16-ayu-mirage.conf
+++ b/colors/base16-ayu-mirage.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Ayu Mirage
+## author:   Khue Nguyen &lt;Z5483Y@gmail.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Ayu Mirage
+
 # Scheme name: base16 Ayu Mirage
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171b24
 foreground #cccac2
 selection_background #707a8c
 selection_foreground #cccac2
-url_color #8a9199
+
+# Cursor colors
 cursor #cccac2
 cursor_text_color #171b24
+
+# URL underline color when hovering with mouse
+url_color #8a9199
+
+# Kitty window border colors
 active_border_color #707a8c
 inactive_border_color #1f2430
+
+# OS Window titlebar colors
+wayland_titlebar_color #171b24
+macos_titlebar_color #171b24
+
+# Tab bar colors
 active_tab_background #171b24
 active_tab_foreground #cccac2
 inactive_tab_background #1f2430
 inactive_tab_foreground #8a9199
 tab_bar_background #1f2430
-wayland_titlebar_color #171b24
-macos_titlebar_color #171b24
 
+# The 16 terminal colors
 # normal
 color0 #171b24
 color1 #f28779

--- a/colors/base16-aztec.conf
+++ b/colors/base16-aztec.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Aztec
+## author:   TheNeverMan (github.com/TheNeverMan)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Aztec
+
 # Scheme name: base16 Aztec
 # Scheme author: TheNeverMan (github.com/TheNeverMan)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #101600
 foreground #ffda51
 selection_background #2e2e05
 selection_foreground #ffda51
-url_color #ffd129
+
+# Cursor colors
 cursor #ffda51
 cursor_text_color #101600
+
+# URL underline color when hovering with mouse
+url_color #ffd129
+
+# Kitty window border colors
 active_border_color #2e2e05
 inactive_border_color #1a1e01
+
+# OS Window titlebar colors
+wayland_titlebar_color #101600
+macos_titlebar_color #101600
+
+# Tab bar colors
 active_tab_background #101600
 active_tab_foreground #ffda51
 inactive_tab_background #1a1e01
 inactive_tab_foreground #ffd129
 tab_bar_background #1a1e01
-wayland_titlebar_color #101600
-macos_titlebar_color #101600
 
+# The 16 terminal colors
 # normal
 color0 #101600
 color1 #ee2e00

--- a/colors/base16-bespin.conf
+++ b/colors/base16-bespin.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Bespin
+## author:   Jan T. Sott
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Bespin
+
 # Scheme name: base16 Bespin
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #28211c
 foreground #8a8986
 selection_background #666666
 selection_foreground #8a8986
-url_color #797977
+
+# Cursor colors
 cursor #8a8986
 cursor_text_color #28211c
+
+# URL underline color when hovering with mouse
+url_color #797977
+
+# Kitty window border colors
 active_border_color #666666
 inactive_border_color #36312e
+
+# OS Window titlebar colors
+wayland_titlebar_color #28211c
+macos_titlebar_color #28211c
+
+# Tab bar colors
 active_tab_background #28211c
 active_tab_foreground #8a8986
 inactive_tab_background #36312e
 inactive_tab_foreground #797977
 tab_bar_background #36312e
-wayland_titlebar_color #28211c
-macos_titlebar_color #28211c
 
+# The 16 terminal colors
 # normal
 color0 #28211c
 color1 #cf6a4c

--- a/colors/base16-black-metal-bathory.conf
+++ b/colors/base16-black-metal-bathory.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Bathory)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Bathory)
+
 # Scheme name: base16 Black Metal (Bathory)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-burzum.conf
+++ b/colors/base16-black-metal-burzum.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Burzum)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Burzum)
+
 # Scheme name: base16 Black Metal (Burzum)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-dark-funeral.conf
+++ b/colors/base16-black-metal-dark-funeral.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Dark Funeral)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Dark Funeral)
+
 # Scheme name: base16 Black Metal (Dark Funeral)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-gorgoroth.conf
+++ b/colors/base16-black-metal-gorgoroth.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Gorgoroth)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Gorgoroth)
+
 # Scheme name: base16 Black Metal (Gorgoroth)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-immortal.conf
+++ b/colors/base16-black-metal-immortal.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Immortal)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Immortal)
+
 # Scheme name: base16 Black Metal (Immortal)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-khold.conf
+++ b/colors/base16-black-metal-khold.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Khold)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Khold)
+
 # Scheme name: base16 Black Metal (Khold)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-marduk.conf
+++ b/colors/base16-black-metal-marduk.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Marduk)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Marduk)
+
 # Scheme name: base16 Black Metal (Marduk)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-mayhem.conf
+++ b/colors/base16-black-metal-mayhem.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Mayhem)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Mayhem)
+
 # Scheme name: base16 Black Metal (Mayhem)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-nile.conf
+++ b/colors/base16-black-metal-nile.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Nile)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Nile)
+
 # Scheme name: base16 Black Metal (Nile)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal-venom.conf
+++ b/colors/base16-black-metal-venom.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal (Venom)
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal (Venom)
+
 # Scheme name: base16 Black Metal (Venom)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-black-metal.conf
+++ b/colors/base16-black-metal.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Black Metal
+## author:   metalelf0 (https://github.com/metalelf0)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Black Metal
+
 # Scheme name: base16 Black Metal
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c1c1c1
 selection_background #333333
 selection_foreground #c1c1c1
-url_color #999999
+
+# Cursor colors
 cursor #c1c1c1
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #121212
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c1c1c1
 inactive_tab_background #121212
 inactive_tab_foreground #999999
 tab_bar_background #121212
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #5f8787

--- a/colors/base16-blueforest.conf
+++ b/colors/base16-blueforest.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Blue Forest
+## author:   alonsodomin (https://github.com/alonsodomin)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Blue Forest
+
 # Scheme name: base16 Blue Forest
 # Scheme author: alonsodomin (https://github.com/alonsodomin)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #141f2e
 foreground #ffcc33
 selection_background #a0ffa0
 selection_foreground #ffcc33
-url_color #1e5c1e
+
+# Cursor colors
 cursor #ffcc33
 cursor_text_color #141f2e
+
+# URL underline color when hovering with mouse
+url_color #1e5c1e
+
+# Kitty window border colors
 active_border_color #a0ffa0
 inactive_border_color #1e5c1e
+
+# OS Window titlebar colors
+wayland_titlebar_color #141f2e
+macos_titlebar_color #141f2e
+
+# Tab bar colors
 active_tab_background #141f2e
 active_tab_foreground #ffcc33
 inactive_tab_background #1e5c1e
 inactive_tab_foreground #1e5c1e
 tab_bar_background #1e5c1e
-wayland_titlebar_color #141f2e
-macos_titlebar_color #141f2e
 
+# The 16 terminal colors
 # normal
 color0 #141f2e
 color1 #fffab1

--- a/colors/base16-blueish.conf
+++ b/colors/base16-blueish.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Blueish
+## author:   Ben Mayoras
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Blueish
+
 # Scheme name: base16 Blueish
 # Scheme author: Ben Mayoras
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #182430
 foreground #c8e1f8
 selection_background #616d78
 selection_foreground #c8e1f8
-url_color #74afe7
+
+# Cursor colors
 cursor #c8e1f8
 cursor_text_color #182430
+
+# URL underline color when hovering with mouse
+url_color #74afe7
+
+# Kitty window border colors
 active_border_color #616d78
 inactive_border_color #243c54
+
+# OS Window titlebar colors
+wayland_titlebar_color #182430
+macos_titlebar_color #182430
+
+# Tab bar colors
 active_tab_background #182430
 active_tab_foreground #c8e1f8
 inactive_tab_background #243c54
 inactive_tab_foreground #74afe7
 tab_bar_background #243c54
-wayland_titlebar_color #182430
-macos_titlebar_color #182430
 
+# The 16 terminal colors
 # normal
 color0 #182430
 color1 #4ce587

--- a/colors/base16-brewer.conf
+++ b/colors/base16-brewer.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Brewer
+## author:   Timothée Poisot (http://github.com/tpoisot)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Brewer
+
 # Scheme name: base16 Brewer
 # Scheme author: Timothée Poisot (http://github.com/tpoisot)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0c0d0e
 foreground #b7b8b9
 selection_background #737475
 selection_foreground #b7b8b9
-url_color #959697
+
+# Cursor colors
 cursor #b7b8b9
 cursor_text_color #0c0d0e
+
+# URL underline color when hovering with mouse
+url_color #959697
+
+# Kitty window border colors
 active_border_color #737475
 inactive_border_color #2e2f30
+
+# OS Window titlebar colors
+wayland_titlebar_color #0c0d0e
+macos_titlebar_color #0c0d0e
+
+# Tab bar colors
 active_tab_background #0c0d0e
 active_tab_foreground #b7b8b9
 inactive_tab_background #2e2f30
 inactive_tab_foreground #959697
 tab_bar_background #2e2f30
-wayland_titlebar_color #0c0d0e
-macos_titlebar_color #0c0d0e
 
+# The 16 terminal colors
 # normal
 color0 #0c0d0e
 color1 #e31a1c

--- a/colors/base16-bright.conf
+++ b/colors/base16-bright.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Bright
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Bright
+
 # Scheme name: base16 Bright
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #e0e0e0
 selection_background #b0b0b0
 selection_foreground #e0e0e0
-url_color #d0d0d0
+
+# Cursor colors
 cursor #e0e0e0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #d0d0d0
+
+# Kitty window border colors
 active_border_color #b0b0b0
 inactive_border_color #303030
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #e0e0e0
 inactive_tab_background #303030
 inactive_tab_foreground #d0d0d0
 tab_bar_background #303030
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #fb0120

--- a/colors/base16-brogrammer.conf
+++ b/colors/base16-brogrammer.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Brogrammer
+## author:   Vik Ramanujam (http://github.com/piggyslasher)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Brogrammer
+
 # Scheme name: base16 Brogrammer
 # Scheme author: Vik Ramanujam (http://github.com/piggyslasher)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1f1f1f
 foreground #4e5ab7
 selection_background #ecba0f
 selection_foreground #4e5ab7
-url_color #2a84d2
+
+# Cursor colors
 cursor #4e5ab7
 cursor_text_color #1f1f1f
+
+# URL underline color when hovering with mouse
+url_color #2a84d2
+
+# Kitty window border colors
 active_border_color #ecba0f
 inactive_border_color #f81118
+
+# OS Window titlebar colors
+wayland_titlebar_color #1f1f1f
+macos_titlebar_color #1f1f1f
+
+# Tab bar colors
 active_tab_background #1f1f1f
 active_tab_foreground #4e5ab7
 inactive_tab_background #f81118
 inactive_tab_foreground #2a84d2
 tab_bar_background #f81118
-wayland_titlebar_color #1f1f1f
-macos_titlebar_color #1f1f1f
 
+# The 16 terminal colors
 # normal
 color0 #1f1f1f
 color1 #d6dbe5

--- a/colors/base16-brushtrees-dark.conf
+++ b/colors/base16-brushtrees-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Brush Trees Dark
+## author:   Abraham White &lt;abelincoln.white@gmail.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Brush Trees Dark
+
 # Scheme name: base16 Brush Trees Dark
 # Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #485867
 foreground #b0c5c8
 selection_background #8299a1
 selection_foreground #b0c5c8
-url_color #98afb5
+
+# Cursor colors
 cursor #b0c5c8
 cursor_text_color #485867
+
+# URL underline color when hovering with mouse
+url_color #98afb5
+
+# Kitty window border colors
 active_border_color #8299a1
 inactive_border_color #5a6d7a
+
+# OS Window titlebar colors
+wayland_titlebar_color #485867
+macos_titlebar_color #485867
+
+# Tab bar colors
 active_tab_background #485867
 active_tab_foreground #b0c5c8
 inactive_tab_background #5a6d7a
 inactive_tab_foreground #98afb5
 tab_bar_background #5a6d7a
-wayland_titlebar_color #485867
-macos_titlebar_color #485867
 
+# The 16 terminal colors
 # normal
 color0 #485867
 color1 #b38686

--- a/colors/base16-brushtrees.conf
+++ b/colors/base16-brushtrees.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Brush Trees
+## author:   Abraham White &lt;abelincoln.white@gmail.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Brush Trees
+
 # Scheme name: base16 Brush Trees
 # Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #e3efef
 foreground #6d828e
 selection_background #98afb5
 selection_foreground #6d828e
-url_color #8299a1
+
+# Cursor colors
 cursor #6d828e
 cursor_text_color #e3efef
+
+# URL underline color when hovering with mouse
+url_color #8299a1
+
+# Kitty window border colors
 active_border_color #98afb5
 inactive_border_color #c9dbdc
+
+# OS Window titlebar colors
+wayland_titlebar_color #e3efef
+macos_titlebar_color #e3efef
+
+# Tab bar colors
 active_tab_background #e3efef
 active_tab_foreground #6d828e
 inactive_tab_background #c9dbdc
 inactive_tab_foreground #8299a1
 tab_bar_background #c9dbdc
-wayland_titlebar_color #e3efef
-macos_titlebar_color #e3efef
 
+# The 16 terminal colors
 # normal
 color0 #e3efef
 color1 #b38686

--- a/colors/base16-caroline.conf
+++ b/colors/base16-caroline.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 caroline
+## author:   ed (https://codeberg.org/ed)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    caroline
+
 # Scheme name: base16 caroline
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1213
 foreground #a87569
 selection_background #6d4745
 selection_foreground #a87569
-url_color #8b5d57
+
+# Cursor colors
 cursor #a87569
 cursor_text_color #1c1213
+
+# URL underline color when hovering with mouse
+url_color #8b5d57
+
+# Kitty window border colors
 active_border_color #6d4745
 inactive_border_color #3a2425
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1213
+macos_titlebar_color #1c1213
+
+# Tab bar colors
 active_tab_background #1c1213
 active_tab_foreground #a87569
 inactive_tab_background #3a2425
 inactive_tab_foreground #8b5d57
 tab_bar_background #3a2425
-wayland_titlebar_color #1c1213
-macos_titlebar_color #1c1213
 
+# The 16 terminal colors
 # normal
 color0 #1c1213
 color1 #c24f57

--- a/colors/base16-catppuccin-frappe.conf
+++ b/colors/base16-catppuccin-frappe.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Catppuccin Frappe
+## author:   https://github.com/catppuccin/catppuccin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Catppuccin Frappe
+
 # Scheme name: base16 Catppuccin Frappe
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #303446
 foreground #c6d0f5
 selection_background #51576d
 selection_foreground #c6d0f5
-url_color #626880
+
+# Cursor colors
 cursor #c6d0f5
 cursor_text_color #303446
+
+# URL underline color when hovering with mouse
+url_color #626880
+
+# Kitty window border colors
 active_border_color #51576d
 inactive_border_color #292c3c
+
+# OS Window titlebar colors
+wayland_titlebar_color #303446
+macos_titlebar_color #303446
+
+# Tab bar colors
 active_tab_background #303446
 active_tab_foreground #c6d0f5
 inactive_tab_background #292c3c
 inactive_tab_foreground #626880
 tab_bar_background #292c3c
-wayland_titlebar_color #303446
-macos_titlebar_color #303446
 
+# The 16 terminal colors
 # normal
 color0 #303446
 color1 #e78284

--- a/colors/base16-catppuccin-latte.conf
+++ b/colors/base16-catppuccin-latte.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Catppuccin Latte
+## author:   https://github.com/catppuccin/catppuccin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Catppuccin Latte
+
 # Scheme name: base16 Catppuccin Latte
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #eff1f5
 foreground #4c4f69
 selection_background #bcc0cc
 selection_foreground #4c4f69
-url_color #acb0be
+
+# Cursor colors
 cursor #4c4f69
 cursor_text_color #eff1f5
+
+# URL underline color when hovering with mouse
+url_color #acb0be
+
+# Kitty window border colors
 active_border_color #bcc0cc
 inactive_border_color #e6e9ef
+
+# OS Window titlebar colors
+wayland_titlebar_color #eff1f5
+macos_titlebar_color #eff1f5
+
+# Tab bar colors
 active_tab_background #eff1f5
 active_tab_foreground #4c4f69
 inactive_tab_background #e6e9ef
 inactive_tab_foreground #acb0be
 tab_bar_background #e6e9ef
-wayland_titlebar_color #eff1f5
-macos_titlebar_color #eff1f5
 
+# The 16 terminal colors
 # normal
 color0 #eff1f5
 color1 #d20f39

--- a/colors/base16-catppuccin-macchiato.conf
+++ b/colors/base16-catppuccin-macchiato.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Catppuccin Macchiato
+## author:   https://github.com/catppuccin/catppuccin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Catppuccin Macchiato
+
 # Scheme name: base16 Catppuccin Macchiato
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #24273a
 foreground #cad3f5
 selection_background #494d64
 selection_foreground #cad3f5
-url_color #5b6078
+
+# Cursor colors
 cursor #cad3f5
 cursor_text_color #24273a
+
+# URL underline color when hovering with mouse
+url_color #5b6078
+
+# Kitty window border colors
 active_border_color #494d64
 inactive_border_color #1e2030
+
+# OS Window titlebar colors
+wayland_titlebar_color #24273a
+macos_titlebar_color #24273a
+
+# Tab bar colors
 active_tab_background #24273a
 active_tab_foreground #cad3f5
 inactive_tab_background #1e2030
 inactive_tab_foreground #5b6078
 tab_bar_background #1e2030
-wayland_titlebar_color #24273a
-macos_titlebar_color #24273a
 
+# The 16 terminal colors
 # normal
 color0 #24273a
 color1 #ed8796

--- a/colors/base16-catppuccin-mocha.conf
+++ b/colors/base16-catppuccin-mocha.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Catppuccin Mocha
+## author:   https://github.com/catppuccin/catppuccin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Catppuccin Mocha
+
 # Scheme name: base16 Catppuccin Mocha
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1e1e2e
 foreground #cdd6f4
 selection_background #45475a
 selection_foreground #cdd6f4
-url_color #585b70
+
+# Cursor colors
 cursor #cdd6f4
 cursor_text_color #1e1e2e
+
+# URL underline color when hovering with mouse
+url_color #585b70
+
+# Kitty window border colors
 active_border_color #45475a
 inactive_border_color #181825
+
+# OS Window titlebar colors
+wayland_titlebar_color #1e1e2e
+macos_titlebar_color #1e1e2e
+
+# Tab bar colors
 active_tab_background #1e1e2e
 active_tab_foreground #cdd6f4
 inactive_tab_background #181825
 inactive_tab_foreground #585b70
 tab_bar_background #181825
-wayland_titlebar_color #1e1e2e
-macos_titlebar_color #1e1e2e
 
+# The 16 terminal colors
 # normal
 color0 #1e1e2e
 color1 #f38ba8

--- a/colors/base16-chalk.conf
+++ b/colors/base16-chalk.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Chalk
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Chalk
+
 # Scheme name: base16 Chalk
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #151515
 foreground #d0d0d0
 selection_background #505050
 selection_foreground #d0d0d0
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #151515
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #151515
+macos_titlebar_color #151515
+
+# Tab bar colors
 active_tab_background #151515
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #151515
-macos_titlebar_color #151515
 
+# The 16 terminal colors
 # normal
 color0 #151515
 color1 #fb9fb1

--- a/colors/base16-circus.conf
+++ b/colors/base16-circus.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Circus
+## author:   Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Circus
+
 # Scheme name: base16 Circus
 # Scheme author: Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #191919
 foreground #a7a7a7
 selection_background #5f5a60
 selection_foreground #a7a7a7
-url_color #505050
+
+# Cursor colors
 cursor #a7a7a7
 cursor_text_color #191919
+
+# URL underline color when hovering with mouse
+url_color #505050
+
+# Kitty window border colors
 active_border_color #5f5a60
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #191919
+macos_titlebar_color #191919
+
+# Tab bar colors
 active_tab_background #191919
 active_tab_foreground #a7a7a7
 inactive_tab_background #202020
 inactive_tab_foreground #505050
 tab_bar_background #202020
-wayland_titlebar_color #191919
-macos_titlebar_color #191919
 
+# The 16 terminal colors
 # normal
 color0 #191919
 color1 #dc657d

--- a/colors/base16-classic-dark.conf
+++ b/colors/base16-classic-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Classic Dark
+## author:   Jason Heeris (http://heeris.id.au)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Classic Dark
+
 # Scheme name: base16 Classic Dark
 # Scheme author: Jason Heeris (http://heeris.id.au)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #151515
 foreground #d0d0d0
 selection_background #505050
 selection_foreground #d0d0d0
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #151515
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #151515
+macos_titlebar_color #151515
+
+# Tab bar colors
 active_tab_background #151515
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #151515
-macos_titlebar_color #151515
 
+# The 16 terminal colors
 # normal
 color0 #151515
 color1 #ac4142

--- a/colors/base16-classic-light.conf
+++ b/colors/base16-classic-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Classic Light
+## author:   Jason Heeris (http://heeris.id.au)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Classic Light
+
 # Scheme name: base16 Classic Light
 # Scheme author: Jason Heeris (http://heeris.id.au)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f5f5f5
 foreground #303030
 selection_background #b0b0b0
 selection_foreground #303030
-url_color #505050
+
+# Cursor colors
 cursor #303030
 cursor_text_color #f5f5f5
+
+# URL underline color when hovering with mouse
+url_color #505050
+
+# Kitty window border colors
 active_border_color #b0b0b0
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #f5f5f5
+macos_titlebar_color #f5f5f5
+
+# Tab bar colors
 active_tab_background #f5f5f5
 active_tab_foreground #303030
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #505050
 tab_bar_background #e0e0e0
-wayland_titlebar_color #f5f5f5
-macos_titlebar_color #f5f5f5
 
+# The 16 terminal colors
 # normal
 color0 #f5f5f5
 color1 #ac4142

--- a/colors/base16-codeschool.conf
+++ b/colors/base16-codeschool.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Codeschool
+## author:   blockloop
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Codeschool
+
 # Scheme name: base16 Codeschool
 # Scheme author: blockloop
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #232c31
 foreground #9ea7a6
 selection_background #3f4944
 selection_foreground #9ea7a6
-url_color #84898c
+
+# Cursor colors
 cursor #9ea7a6
 cursor_text_color #232c31
+
+# URL underline color when hovering with mouse
+url_color #84898c
+
+# Kitty window border colors
 active_border_color #3f4944
 inactive_border_color #1c3657
+
+# OS Window titlebar colors
+wayland_titlebar_color #232c31
+macos_titlebar_color #232c31
+
+# Tab bar colors
 active_tab_background #232c31
 active_tab_foreground #9ea7a6
 inactive_tab_background #1c3657
 inactive_tab_foreground #84898c
 tab_bar_background #1c3657
-wayland_titlebar_color #232c31
-macos_titlebar_color #232c31
 
+# The 16 terminal colors
 # normal
 color0 #232c31
 color1 #2a5491

--- a/colors/base16-colors.conf
+++ b/colors/base16-colors.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Colors
+## author:   mrmrs (http://clrs.cc)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Colors
+
 # Scheme name: base16 Colors
 # Scheme author: mrmrs (http://clrs.cc)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #111111
 foreground #bbbbbb
 selection_background #777777
 selection_foreground #bbbbbb
-url_color #999999
+
+# Cursor colors
 cursor #bbbbbb
 cursor_text_color #111111
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #333333
+
+# OS Window titlebar colors
+wayland_titlebar_color #111111
+macos_titlebar_color #111111
+
+# Tab bar colors
 active_tab_background #111111
 active_tab_foreground #bbbbbb
 inactive_tab_background #333333
 inactive_tab_foreground #999999
 tab_bar_background #333333
-wayland_titlebar_color #111111
-macos_titlebar_color #111111
 
+# The 16 terminal colors
 # normal
 color0 #111111
 color1 #ff4136

--- a/colors/base16-cupcake.conf
+++ b/colors/base16-cupcake.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Cupcake
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Cupcake
+
 # Scheme name: base16 Cupcake
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbf1f2
 foreground #8b8198
 selection_background #bfb9c6
 selection_foreground #8b8198
-url_color #a59daf
+
+# Cursor colors
 cursor #8b8198
 cursor_text_color #fbf1f2
+
+# URL underline color when hovering with mouse
+url_color #a59daf
+
+# Kitty window border colors
 active_border_color #bfb9c6
 inactive_border_color #f2f1f4
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbf1f2
+macos_titlebar_color #fbf1f2
+
+# Tab bar colors
 active_tab_background #fbf1f2
 active_tab_foreground #8b8198
 inactive_tab_background #f2f1f4
 inactive_tab_foreground #a59daf
 tab_bar_background #f2f1f4
-wayland_titlebar_color #fbf1f2
-macos_titlebar_color #fbf1f2
 
+# The 16 terminal colors
 # normal
 color0 #fbf1f2
 color1 #d57e85

--- a/colors/base16-cupertino.conf
+++ b/colors/base16-cupertino.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Cupertino
+## author:   Defman21
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Cupertino
+
 # Scheme name: base16 Cupertino
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #404040
 selection_background #808080
 selection_foreground #404040
-url_color #808080
+
+# Cursor colors
 cursor #404040
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #808080
+
+# Kitty window border colors
 active_border_color #808080
 inactive_border_color #c0c0c0
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #404040
 inactive_tab_background #c0c0c0
 inactive_tab_foreground #808080
 tab_bar_background #c0c0c0
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #c41a15

--- a/colors/base16-da-one-black.conf
+++ b/colors/base16-da-one-black.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One Black
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One Black
+
 # Scheme name: base16 Da One Black
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #ffffff
 selection_background #888888
 selection_foreground #ffffff
-url_color #c8c8c8
+
+# Cursor colors
 cursor #ffffff
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #c8c8c8
+
+# Kitty window border colors
 active_border_color #888888
 inactive_border_color #282828
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #ffffff
 inactive_tab_background #282828
 inactive_tab_foreground #c8c8c8
 tab_bar_background #282828
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #fa7883

--- a/colors/base16-da-one-gray.conf
+++ b/colors/base16-da-one-gray.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One Gray
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One Gray
+
 # Scheme name: base16 Da One Gray
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #181818
 foreground #ffffff
 selection_background #888888
 selection_foreground #ffffff
-url_color #c8c8c8
+
+# Cursor colors
 cursor #ffffff
 cursor_text_color #181818
+
+# URL underline color when hovering with mouse
+url_color #c8c8c8
+
+# Kitty window border colors
 active_border_color #888888
 inactive_border_color #282828
+
+# OS Window titlebar colors
+wayland_titlebar_color #181818
+macos_titlebar_color #181818
+
+# Tab bar colors
 active_tab_background #181818
 active_tab_foreground #ffffff
 inactive_tab_background #282828
 inactive_tab_foreground #c8c8c8
 tab_bar_background #282828
-wayland_titlebar_color #181818
-macos_titlebar_color #181818
 
+# The 16 terminal colors
 # normal
 color0 #181818
 color1 #fa7883

--- a/colors/base16-da-one-ocean.conf
+++ b/colors/base16-da-one-ocean.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One Ocean
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One Ocean
+
 # Scheme name: base16 Da One Ocean
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171726
 foreground #ffffff
 selection_background #878d96
 selection_foreground #ffffff
-url_color #c8c8c8
+
+# Cursor colors
 cursor #ffffff
 cursor_text_color #171726
+
+# URL underline color when hovering with mouse
+url_color #c8c8c8
+
+# Kitty window border colors
 active_border_color #878d96
 inactive_border_color #22273d
+
+# OS Window titlebar colors
+wayland_titlebar_color #171726
+macos_titlebar_color #171726
+
+# Tab bar colors
 active_tab_background #171726
 active_tab_foreground #ffffff
 inactive_tab_background #22273d
 inactive_tab_foreground #c8c8c8
 tab_bar_background #22273d
-wayland_titlebar_color #171726
-macos_titlebar_color #171726
 
+# The 16 terminal colors
 # normal
 color0 #171726
 color1 #fa7883

--- a/colors/base16-da-one-paper.conf
+++ b/colors/base16-da-one-paper.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One Paper
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One Paper
+
 # Scheme name: base16 Da One Paper
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #faf0dc
 foreground #181818
 selection_background #585858
 selection_foreground #181818
-url_color #282828
+
+# Cursor colors
 cursor #181818
 cursor_text_color #faf0dc
+
+# URL underline color when hovering with mouse
+url_color #282828
+
+# Kitty window border colors
 active_border_color #585858
 inactive_border_color #c8c8c8
+
+# OS Window titlebar colors
+wayland_titlebar_color #faf0dc
+macos_titlebar_color #faf0dc
+
+# Tab bar colors
 active_tab_background #faf0dc
 active_tab_foreground #181818
 inactive_tab_background #c8c8c8
 inactive_tab_foreground #282828
 tab_bar_background #c8c8c8
-wayland_titlebar_color #faf0dc
-macos_titlebar_color #faf0dc
 
+# The 16 terminal colors
 # normal
 color0 #faf0dc
 color1 #de5d6e

--- a/colors/base16-da-one-sea.conf
+++ b/colors/base16-da-one-sea.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One Sea
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One Sea
+
 # Scheme name: base16 Da One Sea
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #22273d
 foreground #ffffff
 selection_background #878d96
 selection_foreground #ffffff
-url_color #c8c8c8
+
+# Cursor colors
 cursor #ffffff
 cursor_text_color #22273d
+
+# URL underline color when hovering with mouse
+url_color #c8c8c8
+
+# Kitty window border colors
 active_border_color #878d96
 inactive_border_color #374059
+
+# OS Window titlebar colors
+wayland_titlebar_color #22273d
+macos_titlebar_color #22273d
+
+# Tab bar colors
 active_tab_background #22273d
 active_tab_foreground #ffffff
 inactive_tab_background #374059
 inactive_tab_foreground #c8c8c8
 tab_bar_background #374059
-wayland_titlebar_color #22273d
-macos_titlebar_color #22273d
 
+# The 16 terminal colors
 # normal
 color0 #22273d
 color1 #fa7883

--- a/colors/base16-da-one-white.conf
+++ b/colors/base16-da-one-white.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Da One White
+## author:   NNB (https://github.com/NNBnh)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Da One White
+
 # Scheme name: base16 Da One White
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #181818
 selection_background #585858
 selection_foreground #181818
-url_color #282828
+
+# Cursor colors
 cursor #181818
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #282828
+
+# Kitty window border colors
 active_border_color #585858
 inactive_border_color #c8c8c8
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #181818
 inactive_tab_background #c8c8c8
 inactive_tab_foreground #282828
 tab_bar_background #c8c8c8
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #de5d6e

--- a/colors/base16-danqing-light.conf
+++ b/colors/base16-danqing-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 DanQing Light
+## author:   Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    DanQing Light
+
 # Scheme name: base16 DanQing Light
 # Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fcfefd
 foreground #5a605d
 selection_background #cad8d2
 selection_foreground #5a605d
-url_color #9da8a3
+
+# Cursor colors
 cursor #5a605d
 cursor_text_color #fcfefd
+
+# URL underline color when hovering with mouse
+url_color #9da8a3
+
+# Kitty window border colors
 active_border_color #cad8d2
 inactive_border_color #ecf6f2
+
+# OS Window titlebar colors
+wayland_titlebar_color #fcfefd
+macos_titlebar_color #fcfefd
+
+# Tab bar colors
 active_tab_background #fcfefd
 active_tab_foreground #5a605d
 inactive_tab_background #ecf6f2
 inactive_tab_foreground #9da8a3
 tab_bar_background #ecf6f2
-wayland_titlebar_color #fcfefd
-macos_titlebar_color #fcfefd
 
+# The 16 terminal colors
 # normal
 color0 #fcfefd
 color1 #f9906f

--- a/colors/base16-danqing.conf
+++ b/colors/base16-danqing.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 DanQing
+## author:   Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    DanQing
+
 # Scheme name: base16 DanQing
 # Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d302f
 foreground #e0f0ef
 selection_background #9da8a3
 selection_foreground #e0f0ef
-url_color #cad8d2
+
+# Cursor colors
 cursor #e0f0ef
 cursor_text_color #2d302f
+
+# URL underline color when hovering with mouse
+url_color #cad8d2
+
+# Kitty window border colors
 active_border_color #9da8a3
 inactive_border_color #434846
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d302f
+macos_titlebar_color #2d302f
+
+# Tab bar colors
 active_tab_background #2d302f
 active_tab_foreground #e0f0ef
 inactive_tab_background #434846
 inactive_tab_foreground #cad8d2
 tab_bar_background #434846
-wayland_titlebar_color #2d302f
-macos_titlebar_color #2d302f
 
+# The 16 terminal colors
 # normal
 color0 #2d302f
 color1 #f9906f

--- a/colors/base16-darcula.conf
+++ b/colors/base16-darcula.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Darcula
+## author:   jetbrains
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Darcula
+
 # Scheme name: base16 Darcula
 # Scheme author: jetbrains
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2b2b2b
 foreground #a9b7c6
 selection_background #606366
 selection_foreground #a9b7c6
-url_color #a4a3a3
+
+# Cursor colors
 cursor #a9b7c6
 cursor_text_color #2b2b2b
+
+# URL underline color when hovering with mouse
+url_color #a4a3a3
+
+# Kitty window border colors
 active_border_color #606366
 inactive_border_color #323232
+
+# OS Window titlebar colors
+wayland_titlebar_color #2b2b2b
+macos_titlebar_color #2b2b2b
+
+# Tab bar colors
 active_tab_background #2b2b2b
 active_tab_foreground #a9b7c6
 inactive_tab_background #323232
 inactive_tab_foreground #a4a3a3
 tab_bar_background #323232
-wayland_titlebar_color #2b2b2b
-macos_titlebar_color #2b2b2b
 
+# The 16 terminal colors
 # normal
 color0 #2b2b2b
 color1 #4eade5

--- a/colors/base16-darkmoss.conf
+++ b/colors/base16-darkmoss.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 darkmoss
+## author:   Gabriel Avanzi (https://github.com/avanzzzi)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    darkmoss
+
 # Scheme name: base16 darkmoss
 # Scheme author: Gabriel Avanzi (https://github.com/avanzzzi)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171e1f
 foreground #c7c7a5
 selection_background #555e5f
 selection_foreground #c7c7a5
-url_color #818f80
+
+# Cursor colors
 cursor #c7c7a5
 cursor_text_color #171e1f
+
+# URL underline color when hovering with mouse
+url_color #818f80
+
+# Kitty window border colors
 active_border_color #555e5f
 inactive_border_color #252c2d
+
+# OS Window titlebar colors
+wayland_titlebar_color #171e1f
+macos_titlebar_color #171e1f
+
+# Tab bar colors
 active_tab_background #171e1f
 active_tab_foreground #c7c7a5
 inactive_tab_background #252c2d
 inactive_tab_foreground #818f80
 tab_bar_background #252c2d
-wayland_titlebar_color #171e1f
-macos_titlebar_color #171e1f
 
+# The 16 terminal colors
 # normal
 color0 #171e1f
 color1 #ff4658

--- a/colors/base16-darktooth.conf
+++ b/colors/base16-darktooth.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Darktooth
+## author:   Jason Milkins (https://github.com/jasonm23)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Darktooth
+
 # Scheme name: base16 Darktooth
 # Scheme author: Jason Milkins (https://github.com/jasonm23)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1d2021
 foreground #a89984
 selection_background #665c54
 selection_foreground #a89984
-url_color #928374
+
+# Cursor colors
 cursor #a89984
 cursor_text_color #1d2021
+
+# URL underline color when hovering with mouse
+url_color #928374
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #32302f
+
+# OS Window titlebar colors
+wayland_titlebar_color #1d2021
+macos_titlebar_color #1d2021
+
+# Tab bar colors
 active_tab_background #1d2021
 active_tab_foreground #a89984
 inactive_tab_background #32302f
 inactive_tab_foreground #928374
 tab_bar_background #32302f
-wayland_titlebar_color #1d2021
-macos_titlebar_color #1d2021
 
+# The 16 terminal colors
 # normal
 color0 #1d2021
 color1 #fb543f

--- a/colors/base16-darkviolet.conf
+++ b/colors/base16-darkviolet.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Dark Violet
+## author:   ruler501 (https://github.com/ruler501/base16-darkviolet)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Dark Violet
+
 # Scheme name: base16 Dark Violet
 # Scheme author: ruler501 (https://github.com/ruler501/base16-darkviolet)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #b08ae6
 selection_background #593380
 selection_foreground #b08ae6
-url_color #00ff00
+
+# Cursor colors
 cursor #b08ae6
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #00ff00
+
+# Kitty window border colors
 active_border_color #593380
 inactive_border_color #231a40
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #b08ae6
 inactive_tab_background #231a40
 inactive_tab_foreground #00ff00
 tab_bar_background #231a40
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #a82ee6

--- a/colors/base16-decaf.conf
+++ b/colors/base16-decaf.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Decaf
+## author:   Alex Mirrington (https://github.com/alexmirrington)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Decaf
+
 # Scheme name: base16 Decaf
 # Scheme author: Alex Mirrington (https://github.com/alexmirrington)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d2d2d
 foreground #cccccc
 selection_background #777777
 selection_foreground #cccccc
-url_color #b4b7b4
+
+# Cursor colors
 cursor #cccccc
 cursor_text_color #2d2d2d
+
+# URL underline color when hovering with mouse
+url_color #b4b7b4
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #393939
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d2d2d
+macos_titlebar_color #2d2d2d
+
+# Tab bar colors
 active_tab_background #2d2d2d
 active_tab_foreground #cccccc
 inactive_tab_background #393939
 inactive_tab_foreground #b4b7b4
 tab_bar_background #393939
-wayland_titlebar_color #2d2d2d
-macos_titlebar_color #2d2d2d
 
+# The 16 terminal colors
 # normal
 color0 #2d2d2d
 color1 #ff7f7b

--- a/colors/base16-default-dark.conf
+++ b/colors/base16-default-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Default Dark
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Default Dark
+
 # Scheme name: base16 Default Dark
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #181818
 foreground #d8d8d8
 selection_background #585858
 selection_foreground #d8d8d8
-url_color #b8b8b8
+
+# Cursor colors
 cursor #d8d8d8
 cursor_text_color #181818
+
+# URL underline color when hovering with mouse
+url_color #b8b8b8
+
+# Kitty window border colors
 active_border_color #585858
 inactive_border_color #282828
+
+# OS Window titlebar colors
+wayland_titlebar_color #181818
+macos_titlebar_color #181818
+
+# Tab bar colors
 active_tab_background #181818
 active_tab_foreground #d8d8d8
 inactive_tab_background #282828
 inactive_tab_foreground #b8b8b8
 tab_bar_background #282828
-wayland_titlebar_color #181818
-macos_titlebar_color #181818
 
+# The 16 terminal colors
 # normal
 color0 #181818
 color1 #ab4642

--- a/colors/base16-default-light.conf
+++ b/colors/base16-default-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Default Light
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Default Light
+
 # Scheme name: base16 Default Light
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f8f8f8
 foreground #383838
 selection_background #b8b8b8
 selection_foreground #383838
-url_color #585858
+
+# Cursor colors
 cursor #383838
 cursor_text_color #f8f8f8
+
+# URL underline color when hovering with mouse
+url_color #585858
+
+# Kitty window border colors
 active_border_color #b8b8b8
 inactive_border_color #e8e8e8
+
+# OS Window titlebar colors
+wayland_titlebar_color #f8f8f8
+macos_titlebar_color #f8f8f8
+
+# Tab bar colors
 active_tab_background #f8f8f8
 active_tab_foreground #383838
 inactive_tab_background #e8e8e8
 inactive_tab_foreground #585858
 tab_bar_background #e8e8e8
-wayland_titlebar_color #f8f8f8
-macos_titlebar_color #f8f8f8
 
+# The 16 terminal colors
 # normal
 color0 #f8f8f8
 color1 #ab4642

--- a/colors/base16-dirtysea.conf
+++ b/colors/base16-dirtysea.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 dirtysea
+## author:   Kahlil (Kal) Hodgson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    dirtysea
+
 # Scheme name: base16 dirtysea
 # Scheme author: Kahlil (Kal) Hodgson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #e0e0e0
 foreground #000000
 selection_background #707070
 selection_foreground #000000
-url_color #202020
+
+# Cursor colors
 cursor #000000
 cursor_text_color #e0e0e0
+
+# URL underline color when hovering with mouse
+url_color #202020
+
+# Kitty window border colors
 active_border_color #707070
 inactive_border_color #d0dad0
+
+# OS Window titlebar colors
+wayland_titlebar_color #e0e0e0
+macos_titlebar_color #e0e0e0
+
+# Tab bar colors
 active_tab_background #e0e0e0
 active_tab_foreground #000000
 inactive_tab_background #d0dad0
 inactive_tab_foreground #202020
 tab_bar_background #d0dad0
-wayland_titlebar_color #e0e0e0
-macos_titlebar_color #e0e0e0
 
+# The 16 terminal colors
 # normal
 color0 #e0e0e0
 color1 #840000

--- a/colors/base16-dracula.conf
+++ b/colors/base16-dracula.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Dracula
+## author:   Jamy Golden (http://github.com/JamyGolden), based on Dracula Theme (http://github.com/dracula)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Dracula
+
 # Scheme name: base16 Dracula
 # Scheme author: Jamy Golden (http://github.com/JamyGolden), based on Dracula Theme (http://github.com/dracula)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282a36
 foreground #f8f8f2
 selection_background #6272a4
 selection_foreground #f8f8f2
-url_color #9ea8c7
+
+# Cursor colors
 cursor #f8f8f2
 cursor_text_color #282a36
+
+# URL underline color when hovering with mouse
+url_color #9ea8c7
+
+# Kitty window border colors
 active_border_color #6272a4
 inactive_border_color #363447
+
+# OS Window titlebar colors
+wayland_titlebar_color #282a36
+macos_titlebar_color #282a36
+
+# Tab bar colors
 active_tab_background #282a36
 active_tab_foreground #f8f8f2
 inactive_tab_background #363447
 inactive_tab_foreground #9ea8c7
 tab_bar_background #363447
-wayland_titlebar_color #282a36
-macos_titlebar_color #282a36
 
+# The 16 terminal colors
 # normal
 color0 #282a36
 color1 #ff5555

--- a/colors/base16-edge-dark.conf
+++ b/colors/base16-edge-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Edge Dark
+## author:   cjayross (https://github.com/cjayross)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Edge Dark
+
 # Scheme name: base16 Edge Dark
 # Scheme author: cjayross (https://github.com/cjayross)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #262729
 foreground #b7bec9
 selection_background #3e4249
 selection_foreground #b7bec9
-url_color #73b3e7
+
+# Cursor colors
 cursor #b7bec9
 cursor_text_color #262729
+
+# URL underline color when hovering with mouse
+url_color #73b3e7
+
+# Kitty window border colors
 active_border_color #3e4249
 inactive_border_color #88909f
+
+# OS Window titlebar colors
+wayland_titlebar_color #262729
+macos_titlebar_color #262729
+
+# Tab bar colors
 active_tab_background #262729
 active_tab_foreground #b7bec9
 inactive_tab_background #88909f
 inactive_tab_foreground #73b3e7
 tab_bar_background #88909f
-wayland_titlebar_color #262729
-macos_titlebar_color #262729
 
+# The 16 terminal colors
 # normal
 color0 #262729
 color1 #e77171

--- a/colors/base16-edge-light.conf
+++ b/colors/base16-edge-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Edge Light
+## author:   cjayross (https://github.com/cjayross)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Edge Light
+
 # Scheme name: base16 Edge Light
 # Scheme author: cjayross (https://github.com/cjayross)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fafafa
 foreground #5e646f
 selection_background #5e646f
 selection_foreground #5e646f
-url_color #6587bf
+
+# Cursor colors
 cursor #5e646f
 cursor_text_color #fafafa
+
+# URL underline color when hovering with mouse
+url_color #6587bf
+
+# Kitty window border colors
 active_border_color #5e646f
 inactive_border_color #7c9f4b
+
+# OS Window titlebar colors
+wayland_titlebar_color #fafafa
+macos_titlebar_color #fafafa
+
+# Tab bar colors
 active_tab_background #fafafa
 active_tab_foreground #5e646f
 inactive_tab_background #7c9f4b
 inactive_tab_foreground #6587bf
 tab_bar_background #7c9f4b
-wayland_titlebar_color #fafafa
-macos_titlebar_color #fafafa
 
+# The 16 terminal colors
 # normal
 color0 #fafafa
 color1 #db7070

--- a/colors/base16-eighties.conf
+++ b/colors/base16-eighties.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Eighties
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Eighties
+
 # Scheme name: base16 Eighties
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d2d2d
 foreground #d3d0c8
 selection_background #747369
 selection_foreground #d3d0c8
-url_color #a09f93
+
+# Cursor colors
 cursor #d3d0c8
 cursor_text_color #2d2d2d
+
+# URL underline color when hovering with mouse
+url_color #a09f93
+
+# Kitty window border colors
 active_border_color #747369
 inactive_border_color #393939
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d2d2d
+macos_titlebar_color #2d2d2d
+
+# Tab bar colors
 active_tab_background #2d2d2d
 active_tab_foreground #d3d0c8
 inactive_tab_background #393939
 inactive_tab_foreground #a09f93
 tab_bar_background #393939
-wayland_titlebar_color #2d2d2d
-macos_titlebar_color #2d2d2d
 
+# The 16 terminal colors
 # normal
 color0 #2d2d2d
 color1 #f2777a

--- a/colors/base16-embers-light.conf
+++ b/colors/base16-embers-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Embers Light
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Embers Light
+
 # Scheme name: base16 Embers Light
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #d1d6db
 foreground #323b43
 selection_background #75808a
 selection_foreground #323b43
-url_color #47505a
+
+# Cursor colors
 cursor #323b43
 cursor_text_color #d1d6db
+
+# URL underline color when hovering with mouse
+url_color #47505a
+
+# Kitty window border colors
 active_border_color #75808a
 inactive_border_color #aeb6be
+
+# OS Window titlebar colors
+wayland_titlebar_color #d1d6db
+macos_titlebar_color #d1d6db
+
+# Tab bar colors
 active_tab_background #d1d6db
 active_tab_foreground #323b43
 inactive_tab_background #aeb6be
 inactive_tab_foreground #47505a
 tab_bar_background #aeb6be
-wayland_titlebar_color #d1d6db
-macos_titlebar_color #d1d6db
 
+# The 16 terminal colors
 # normal
 color0 #d1d6db
 color1 #576d82

--- a/colors/base16-embers.conf
+++ b/colors/base16-embers.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Embers
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Embers
+
 # Scheme name: base16 Embers
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #16130f
 foreground #a39a90
 selection_background #5a5047
 selection_foreground #a39a90
-url_color #8a8075
+
+# Cursor colors
 cursor #a39a90
 cursor_text_color #16130f
+
+# URL underline color when hovering with mouse
+url_color #8a8075
+
+# Kitty window border colors
 active_border_color #5a5047
 inactive_border_color #2c2620
+
+# OS Window titlebar colors
+wayland_titlebar_color #16130f
+macos_titlebar_color #16130f
+
+# Tab bar colors
 active_tab_background #16130f
 active_tab_foreground #a39a90
 inactive_tab_background #2c2620
 inactive_tab_foreground #8a8075
 tab_bar_background #2c2620
-wayland_titlebar_color #16130f
-macos_titlebar_color #16130f
 
+# The 16 terminal colors
 # normal
 color0 #16130f
 color1 #826d57

--- a/colors/base16-emil.conf
+++ b/colors/base16-emil.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 emil
+## author:   limelier
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    emil
+
 # Scheme name: base16 emil
 # Scheme author: limelier
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #efefef
 foreground #313145
 selection_background #7c7c98
 selection_foreground #313145
-url_color #505063
+
+# Cursor colors
 cursor #313145
 cursor_text_color #efefef
+
+# URL underline color when hovering with mouse
+url_color #505063
+
+# Kitty window border colors
 active_border_color #7c7c98
 inactive_border_color #bebed2
+
+# OS Window titlebar colors
+wayland_titlebar_color #efefef
+macos_titlebar_color #efefef
+
+# Tab bar colors
 active_tab_background #efefef
 active_tab_foreground #313145
 inactive_tab_background #bebed2
 inactive_tab_foreground #505063
 tab_bar_background #bebed2
-wayland_titlebar_color #efefef
-macos_titlebar_color #efefef
 
+# The 16 terminal colors
 # normal
 color0 #efefef
 color1 #f43979

--- a/colors/base16-equilibrium-dark.conf
+++ b/colors/base16-equilibrium-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Equilibrium Dark
+## author:   Carlo Abelli
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Equilibrium Dark
+
 # Scheme name: base16 Equilibrium Dark
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0c1118
 foreground #afaba2
 selection_background #7b776e
 selection_foreground #afaba2
-url_color #949088
+
+# Cursor colors
 cursor #afaba2
 cursor_text_color #0c1118
+
+# URL underline color when hovering with mouse
+url_color #949088
+
+# Kitty window border colors
 active_border_color #7b776e
 inactive_border_color #181c22
+
+# OS Window titlebar colors
+wayland_titlebar_color #0c1118
+macos_titlebar_color #0c1118
+
+# Tab bar colors
 active_tab_background #0c1118
 active_tab_foreground #afaba2
 inactive_tab_background #181c22
 inactive_tab_foreground #949088
 tab_bar_background #181c22
-wayland_titlebar_color #0c1118
-macos_titlebar_color #0c1118
 
+# The 16 terminal colors
 # normal
 color0 #0c1118
 color1 #f04339

--- a/colors/base16-equilibrium-gray-dark.conf
+++ b/colors/base16-equilibrium-gray-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Equilibrium Gray Dark
+## author:   Carlo Abelli
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Equilibrium Gray Dark
+
 # Scheme name: base16 Equilibrium Gray Dark
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #111111
 foreground #ababab
 selection_background #777777
 selection_foreground #ababab
-url_color #919191
+
+# Cursor colors
 cursor #ababab
 cursor_text_color #111111
+
+# URL underline color when hovering with mouse
+url_color #919191
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #1b1b1b
+
+# OS Window titlebar colors
+wayland_titlebar_color #111111
+macos_titlebar_color #111111
+
+# Tab bar colors
 active_tab_background #111111
 active_tab_foreground #ababab
 inactive_tab_background #1b1b1b
 inactive_tab_foreground #919191
 tab_bar_background #1b1b1b
-wayland_titlebar_color #111111
-macos_titlebar_color #111111
 
+# The 16 terminal colors
 # normal
 color0 #111111
 color1 #f04339

--- a/colors/base16-equilibrium-gray-light.conf
+++ b/colors/base16-equilibrium-gray-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Equilibrium Gray Light
+## author:   Carlo Abelli
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Equilibrium Gray Light
+
 # Scheme name: base16 Equilibrium Gray Light
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f1f1f1
 foreground #474747
 selection_background #777777
 selection_foreground #474747
-url_color #5e5e5e
+
+# Cursor colors
 cursor #474747
 cursor_text_color #f1f1f1
+
+# URL underline color when hovering with mouse
+url_color #5e5e5e
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #e2e2e2
+
+# OS Window titlebar colors
+wayland_titlebar_color #f1f1f1
+macos_titlebar_color #f1f1f1
+
+# Tab bar colors
 active_tab_background #f1f1f1
 active_tab_foreground #474747
 inactive_tab_background #e2e2e2
 inactive_tab_foreground #5e5e5e
 tab_bar_background #e2e2e2
-wayland_titlebar_color #f1f1f1
-macos_titlebar_color #f1f1f1
 
+# The 16 terminal colors
 # normal
 color0 #f1f1f1
 color1 #d02023

--- a/colors/base16-equilibrium-light.conf
+++ b/colors/base16-equilibrium-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Equilibrium Light
+## author:   Carlo Abelli
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Equilibrium Light
+
 # Scheme name: base16 Equilibrium Light
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f5f0e7
 foreground #43474e
 selection_background #73777f
 selection_foreground #43474e
-url_color #5a5f66
+
+# Cursor colors
 cursor #43474e
 cursor_text_color #f5f0e7
+
+# URL underline color when hovering with mouse
+url_color #5a5f66
+
+# Kitty window border colors
 active_border_color #73777f
 inactive_border_color #e7e2d9
+
+# OS Window titlebar colors
+wayland_titlebar_color #f5f0e7
+macos_titlebar_color #f5f0e7
+
+# Tab bar colors
 active_tab_background #f5f0e7
 active_tab_foreground #43474e
 inactive_tab_background #e7e2d9
 inactive_tab_foreground #5a5f66
 tab_bar_background #e7e2d9
-wayland_titlebar_color #f5f0e7
-macos_titlebar_color #f5f0e7
 
+# The 16 terminal colors
 # normal
 color0 #f5f0e7
 color1 #d02023

--- a/colors/base16-eris.conf
+++ b/colors/base16-eris.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 eris
+## author:   ed (https://codeberg.org/ed)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    eris
+
 # Scheme name: base16 eris
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0a0920
 foreground #606bac
 selection_background #333773
 selection_foreground #606bac
-url_color #4a5293
+
+# Cursor colors
 cursor #606bac
 cursor_text_color #0a0920
+
+# URL underline color when hovering with mouse
+url_color #4a5293
+
+# Kitty window border colors
 active_border_color #333773
 inactive_border_color #13133a
+
+# OS Window titlebar colors
+wayland_titlebar_color #0a0920
+macos_titlebar_color #0a0920
+
+# Tab bar colors
 active_tab_background #0a0920
 active_tab_foreground #606bac
 inactive_tab_background #13133a
 inactive_tab_foreground #4a5293
 tab_bar_background #13133a
-wayland_titlebar_color #0a0920
-macos_titlebar_color #0a0920
 
+# The 16 terminal colors
 # normal
 color0 #0a0920
 color1 #f768a3

--- a/colors/base16-espresso.conf
+++ b/colors/base16-espresso.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Espresso
+## author:   Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Espresso
+
 # Scheme name: base16 Espresso
 # Scheme author: Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d2d2d
 foreground #cccccc
 selection_background #777777
 selection_foreground #cccccc
-url_color #b4b7b4
+
+# Cursor colors
 cursor #cccccc
 cursor_text_color #2d2d2d
+
+# URL underline color when hovering with mouse
+url_color #b4b7b4
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #393939
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d2d2d
+macos_titlebar_color #2d2d2d
+
+# Tab bar colors
 active_tab_background #2d2d2d
 active_tab_foreground #cccccc
 inactive_tab_background #393939
 inactive_tab_foreground #b4b7b4
 tab_bar_background #393939
-wayland_titlebar_color #2d2d2d
-macos_titlebar_color #2d2d2d
 
+# The 16 terminal colors
 # normal
 color0 #2d2d2d
 color1 #d25252

--- a/colors/base16-eva-dim.conf
+++ b/colors/base16-eva-dim.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Eva Dim
+## author:   kjakapat (https://github.com/kjakapat)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Eva Dim
+
 # Scheme name: base16 Eva Dim
 # Scheme author: kjakapat (https://github.com/kjakapat)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2a3b4d
 foreground #9fa2a6
 selection_background #55799c
 selection_foreground #9fa2a6
-url_color #7e90a3
+
+# Cursor colors
 cursor #9fa2a6
 cursor_text_color #2a3b4d
+
+# URL underline color when hovering with mouse
+url_color #7e90a3
+
+# Kitty window border colors
 active_border_color #55799c
 inactive_border_color #3d566f
+
+# OS Window titlebar colors
+wayland_titlebar_color #2a3b4d
+macos_titlebar_color #2a3b4d
+
+# Tab bar colors
 active_tab_background #2a3b4d
 active_tab_foreground #9fa2a6
 inactive_tab_background #3d566f
 inactive_tab_foreground #7e90a3
 tab_bar_background #3d566f
-wayland_titlebar_color #2a3b4d
-macos_titlebar_color #2a3b4d
 
+# The 16 terminal colors
 # normal
 color0 #2a3b4d
 color1 #c4676c

--- a/colors/base16-eva.conf
+++ b/colors/base16-eva.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Eva
+## author:   kjakapat (https://github.com/kjakapat)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Eva
+
 # Scheme name: base16 Eva
 # Scheme author: kjakapat (https://github.com/kjakapat)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2a3b4d
 foreground #9fa2a6
 selection_background #55799c
 selection_foreground #9fa2a6
-url_color #7e90a3
+
+# Cursor colors
 cursor #9fa2a6
 cursor_text_color #2a3b4d
+
+# URL underline color when hovering with mouse
+url_color #7e90a3
+
+# Kitty window border colors
 active_border_color #55799c
 inactive_border_color #3d566f
+
+# OS Window titlebar colors
+wayland_titlebar_color #2a3b4d
+macos_titlebar_color #2a3b4d
+
+# Tab bar colors
 active_tab_background #2a3b4d
 active_tab_foreground #9fa2a6
 inactive_tab_background #3d566f
 inactive_tab_foreground #7e90a3
 tab_bar_background #3d566f
-wayland_titlebar_color #2a3b4d
-macos_titlebar_color #2a3b4d
 
+# The 16 terminal colors
 # normal
 color0 #2a3b4d
 color1 #c4676c

--- a/colors/base16-evenok-dark.conf
+++ b/colors/base16-evenok-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Evenok Dark
+## author:   Mekeor Melire
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Evenok Dark
+
 # Scheme name: base16 Evenok Dark
 # Scheme author: Mekeor Melire
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #d0d0d0
 selection_background #505050
 selection_foreground #d0d0d0
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #f5708a

--- a/colors/base16-everforest-dark-hard.conf
+++ b/colors/base16-everforest-dark-hard.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Everforest Dark Hard
+## author:   Sainnhe Park (https://github.com/sainnhe)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Everforest Dark Hard
+
 # Scheme name: base16 Everforest Dark Hard
 # Scheme author: Sainnhe Park (https://github.com/sainnhe)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #272e33
 foreground #d3c6aa
 selection_background #859289
 selection_foreground #d3c6aa
-url_color #9da9a0
+
+# Cursor colors
 cursor #d3c6aa
 cursor_text_color #272e33
+
+# URL underline color when hovering with mouse
+url_color #9da9a0
+
+# Kitty window border colors
 active_border_color #859289
 inactive_border_color #2e383c
+
+# OS Window titlebar colors
+wayland_titlebar_color #272e33
+macos_titlebar_color #272e33
+
+# Tab bar colors
 active_tab_background #272e33
 active_tab_foreground #d3c6aa
 inactive_tab_background #2e383c
 inactive_tab_foreground #9da9a0
 tab_bar_background #2e383c
-wayland_titlebar_color #272e33
-macos_titlebar_color #272e33
 
+# The 16 terminal colors
 # normal
 color0 #272e33
 color1 #e67e80

--- a/colors/base16-everforest.conf
+++ b/colors/base16-everforest.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Everforest
+## author:   Sainnhe Park (https://github.com/sainnhe)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Everforest
+
 # Scheme name: base16 Everforest
 # Scheme author: Sainnhe Park (https://github.com/sainnhe)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d353b
 foreground #d3c6aa
 selection_background #859289
 selection_foreground #d3c6aa
-url_color #9da9a0
+
+# Cursor colors
 cursor #d3c6aa
 cursor_text_color #2d353b
+
+# URL underline color when hovering with mouse
+url_color #9da9a0
+
+# Kitty window border colors
 active_border_color #859289
 inactive_border_color #343f44
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d353b
+macos_titlebar_color #2d353b
+
+# Tab bar colors
 active_tab_background #2d353b
 active_tab_foreground #d3c6aa
 inactive_tab_background #343f44
 inactive_tab_foreground #9da9a0
 tab_bar_background #343f44
-wayland_titlebar_color #2d353b
-macos_titlebar_color #2d353b
 
+# The 16 terminal colors
 # normal
 color0 #2d353b
 color1 #e67e80

--- a/colors/base16-flat.conf
+++ b/colors/base16-flat.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Flat
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Flat
+
 # Scheme name: base16 Flat
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2c3e50
 foreground #e0e0e0
 selection_background #95a5a6
 selection_foreground #e0e0e0
-url_color #bdc3c7
+
+# Cursor colors
 cursor #e0e0e0
 cursor_text_color #2c3e50
+
+# URL underline color when hovering with mouse
+url_color #bdc3c7
+
+# Kitty window border colors
 active_border_color #95a5a6
 inactive_border_color #34495e
+
+# OS Window titlebar colors
+wayland_titlebar_color #2c3e50
+macos_titlebar_color #2c3e50
+
+# Tab bar colors
 active_tab_background #2c3e50
 active_tab_foreground #e0e0e0
 inactive_tab_background #34495e
 inactive_tab_foreground #bdc3c7
 tab_bar_background #34495e
-wayland_titlebar_color #2c3e50
-macos_titlebar_color #2c3e50
 
+# The 16 terminal colors
 # normal
 color0 #2c3e50
 color1 #e74c3c

--- a/colors/base16-framer.conf
+++ b/colors/base16-framer.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Framer
+## author:   Framer (Maintained by Jesse Hoyos)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Framer
+
 # Scheme name: base16 Framer
 # Scheme author: Framer (Maintained by Jesse Hoyos)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #181818
 foreground #d0d0d0
 selection_background #747474
 selection_foreground #d0d0d0
-url_color #b9b9b9
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #181818
+
+# URL underline color when hovering with mouse
+url_color #b9b9b9
+
+# Kitty window border colors
 active_border_color #747474
 inactive_border_color #151515
+
+# OS Window titlebar colors
+wayland_titlebar_color #181818
+macos_titlebar_color #181818
+
+# Tab bar colors
 active_tab_background #181818
 active_tab_foreground #d0d0d0
 inactive_tab_background #151515
 inactive_tab_foreground #b9b9b9
 tab_bar_background #151515
-wayland_titlebar_color #181818
-macos_titlebar_color #181818
 
+# The 16 terminal colors
 # normal
 color0 #181818
 color1 #fd886b

--- a/colors/base16-fruit-soda.conf
+++ b/colors/base16-fruit-soda.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Fruit Soda
+## author:   jozip
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Fruit Soda
+
 # Scheme name: base16 Fruit Soda
 # Scheme author: jozip
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f1ecf1
 foreground #515151
 selection_background #b5b4b6
 selection_foreground #515151
-url_color #979598
+
+# Cursor colors
 cursor #515151
 cursor_text_color #f1ecf1
+
+# URL underline color when hovering with mouse
+url_color #979598
+
+# Kitty window border colors
 active_border_color #b5b4b6
 inactive_border_color #e0dee0
+
+# OS Window titlebar colors
+wayland_titlebar_color #f1ecf1
+macos_titlebar_color #f1ecf1
+
+# Tab bar colors
 active_tab_background #f1ecf1
 active_tab_foreground #515151
 inactive_tab_background #e0dee0
 inactive_tab_foreground #979598
 tab_bar_background #e0dee0
-wayland_titlebar_color #f1ecf1
-macos_titlebar_color #f1ecf1
 
+# The 16 terminal colors
 # normal
 color0 #f1ecf1
 color1 #fe3e31

--- a/colors/base16-gigavolt.conf
+++ b/colors/base16-gigavolt.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gigavolt
+## author:   Aidan Swope (http://github.com/Whillikers)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gigavolt
+
 # Scheme name: base16 Gigavolt
 # Scheme author: Aidan Swope (http://github.com/Whillikers)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #202126
 foreground #e9e7e1
 selection_background #a1d2e6
 selection_foreground #e9e7e1
-url_color #cad3ff
+
+# Cursor colors
 cursor #e9e7e1
 cursor_text_color #202126
+
+# URL underline color when hovering with mouse
+url_color #cad3ff
+
+# Kitty window border colors
 active_border_color #a1d2e6
 inactive_border_color #2d303d
+
+# OS Window titlebar colors
+wayland_titlebar_color #202126
+macos_titlebar_color #202126
+
+# Tab bar colors
 active_tab_background #202126
 active_tab_foreground #e9e7e1
 inactive_tab_background #2d303d
 inactive_tab_foreground #cad3ff
 tab_bar_background #2d303d
-wayland_titlebar_color #202126
-macos_titlebar_color #202126
 
+# The 16 terminal colors
 # normal
 color0 #202126
 color1 #ff661a

--- a/colors/base16-github.conf
+++ b/colors/base16-github.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Github
+## author:   Defman21
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Github
+
 # Scheme name: base16 Github
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #333333
 selection_background #969896
 selection_foreground #333333
-url_color #e8e8e8
+
+# Cursor colors
 cursor #333333
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #e8e8e8
+
+# Kitty window border colors
 active_border_color #969896
 inactive_border_color #f5f5f5
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #333333
 inactive_tab_background #f5f5f5
 inactive_tab_foreground #e8e8e8
 tab_bar_background #f5f5f5
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #ed6a43

--- a/colors/base16-google-dark.conf
+++ b/colors/base16-google-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Google Dark
+## author:   Seth Wright (http://sethawright.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Google Dark
+
 # Scheme name: base16 Google Dark
 # Scheme author: Seth Wright (http://sethawright.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1d1f21
 foreground #c5c8c6
 selection_background #969896
 selection_foreground #c5c8c6
-url_color #b4b7b4
+
+# Cursor colors
 cursor #c5c8c6
 cursor_text_color #1d1f21
+
+# URL underline color when hovering with mouse
+url_color #b4b7b4
+
+# Kitty window border colors
 active_border_color #969896
 inactive_border_color #282a2e
+
+# OS Window titlebar colors
+wayland_titlebar_color #1d1f21
+macos_titlebar_color #1d1f21
+
+# Tab bar colors
 active_tab_background #1d1f21
 active_tab_foreground #c5c8c6
 inactive_tab_background #282a2e
 inactive_tab_foreground #b4b7b4
 tab_bar_background #282a2e
-wayland_titlebar_color #1d1f21
-macos_titlebar_color #1d1f21
 
+# The 16 terminal colors
 # normal
 color0 #1d1f21
 color1 #cc342b

--- a/colors/base16-google-light.conf
+++ b/colors/base16-google-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Google Light
+## author:   Seth Wright (http://sethawright.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Google Light
+
 # Scheme name: base16 Google Light
 # Scheme author: Seth Wright (http://sethawright.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #373b41
 selection_background #b4b7b4
 selection_foreground #373b41
-url_color #969896
+
+# Cursor colors
 cursor #373b41
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #969896
+
+# Kitty window border colors
 active_border_color #b4b7b4
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #373b41
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #969896
 tab_bar_background #e0e0e0
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #cc342b

--- a/colors/base16-gotham.conf
+++ b/colors/base16-gotham.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gotham
+## author:   Andrea Leopardi (arranged by Brett Jones)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gotham
+
 # Scheme name: base16 Gotham
 # Scheme author: Andrea Leopardi (arranged by Brett Jones)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0c1014
 foreground #599cab
 selection_background #0a3749
 selection_foreground #599cab
-url_color #245361
+
+# Cursor colors
 cursor #599cab
 cursor_text_color #0c1014
+
+# URL underline color when hovering with mouse
+url_color #245361
+
+# Kitty window border colors
 active_border_color #0a3749
 inactive_border_color #11151c
+
+# OS Window titlebar colors
+wayland_titlebar_color #0c1014
+macos_titlebar_color #0c1014
+
+# Tab bar colors
 active_tab_background #0c1014
 active_tab_foreground #599cab
 inactive_tab_background #11151c
 inactive_tab_foreground #245361
 tab_bar_background #11151c
-wayland_titlebar_color #0c1014
-macos_titlebar_color #0c1014
 
+# The 16 terminal colors
 # normal
 color0 #0c1014
 color1 #c23127

--- a/colors/base16-grayscale-dark.conf
+++ b/colors/base16-grayscale-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Grayscale Dark
+## author:   Alexandre Gavioli (https://github.com/Alexx2/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Grayscale Dark
+
 # Scheme name: base16 Grayscale Dark
 # Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #101010
 foreground #b9b9b9
 selection_background #525252
 selection_foreground #b9b9b9
-url_color #ababab
+
+# Cursor colors
 cursor #b9b9b9
 cursor_text_color #101010
+
+# URL underline color when hovering with mouse
+url_color #ababab
+
+# Kitty window border colors
 active_border_color #525252
 inactive_border_color #252525
+
+# OS Window titlebar colors
+wayland_titlebar_color #101010
+macos_titlebar_color #101010
+
+# Tab bar colors
 active_tab_background #101010
 active_tab_foreground #b9b9b9
 inactive_tab_background #252525
 inactive_tab_foreground #ababab
 tab_bar_background #252525
-wayland_titlebar_color #101010
-macos_titlebar_color #101010
 
+# The 16 terminal colors
 # normal
 color0 #101010
 color1 #7c7c7c

--- a/colors/base16-grayscale-light.conf
+++ b/colors/base16-grayscale-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Grayscale Light
+## author:   Alexandre Gavioli (https://github.com/Alexx2/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Grayscale Light
+
 # Scheme name: base16 Grayscale Light
 # Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f7f7f7
 foreground #464646
 selection_background #ababab
 selection_foreground #464646
-url_color #525252
+
+# Cursor colors
 cursor #464646
 cursor_text_color #f7f7f7
+
+# URL underline color when hovering with mouse
+url_color #525252
+
+# Kitty window border colors
 active_border_color #ababab
 inactive_border_color #e3e3e3
+
+# OS Window titlebar colors
+wayland_titlebar_color #f7f7f7
+macos_titlebar_color #f7f7f7
+
+# Tab bar colors
 active_tab_background #f7f7f7
 active_tab_foreground #464646
 inactive_tab_background #e3e3e3
 inactive_tab_foreground #525252
 tab_bar_background #e3e3e3
-wayland_titlebar_color #f7f7f7
-macos_titlebar_color #f7f7f7
 
+# The 16 terminal colors
 # normal
 color0 #f7f7f7
 color1 #7c7c7c

--- a/colors/base16-greenscreen.conf
+++ b/colors/base16-greenscreen.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Green Screen
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Green Screen
+
 # Scheme name: base16 Green Screen
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #001100
 foreground #00bb00
 selection_background #007700
 selection_foreground #00bb00
-url_color #009900
+
+# Cursor colors
 cursor #00bb00
 cursor_text_color #001100
+
+# URL underline color when hovering with mouse
+url_color #009900
+
+# Kitty window border colors
 active_border_color #007700
 inactive_border_color #003300
+
+# OS Window titlebar colors
+wayland_titlebar_color #001100
+macos_titlebar_color #001100
+
+# Tab bar colors
 active_tab_background #001100
 active_tab_foreground #00bb00
 inactive_tab_background #003300
 inactive_tab_foreground #009900
 tab_bar_background #003300
-wayland_titlebar_color #001100
-macos_titlebar_color #001100
 
+# The 16 terminal colors
 # normal
 color0 #001100
 color1 #007700

--- a/colors/base16-gruber.conf
+++ b/colors/base16-gruber.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruber
+## author:   Patel, Nimai &lt;nimai.m.patel@gmail.com&gt;, colors from www.github.com/rexim/gruber-darker-theme
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruber
+
 # Scheme name: base16 Gruber
 # Scheme author: Patel, Nimai &lt;nimai.m.patel@gmail.com&gt;, colors from www.github.com/rexim/gruber-darker-theme
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #181818
 foreground #f4f4ff
 selection_background #52494e
 selection_foreground #f4f4ff
-url_color #e4e4ef
+
+# Cursor colors
 cursor #f4f4ff
 cursor_text_color #181818
+
+# URL underline color when hovering with mouse
+url_color #e4e4ef
+
+# Kitty window border colors
 active_border_color #52494e
 inactive_border_color #453d41
+
+# OS Window titlebar colors
+wayland_titlebar_color #181818
+macos_titlebar_color #181818
+
+# Tab bar colors
 active_tab_background #181818
 active_tab_foreground #f4f4ff
 inactive_tab_background #453d41
 inactive_tab_foreground #e4e4ef
 tab_bar_background #453d41
-wayland_titlebar_color #181818
-macos_titlebar_color #181818
 
+# The 16 terminal colors
 # normal
 color0 #181818
 color1 #f43841

--- a/colors/base16-gruvbox-dark-hard.conf
+++ b/colors/base16-gruvbox-dark-hard.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox dark, hard
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox dark, hard
+
 # Scheme name: base16 Gruvbox dark, hard
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1d2021
 foreground #d5c4a1
 selection_background #665c54
 selection_foreground #d5c4a1
-url_color #bdae93
+
+# Cursor colors
 cursor #d5c4a1
 cursor_text_color #1d2021
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #3c3836
+
+# OS Window titlebar colors
+wayland_titlebar_color #1d2021
+macos_titlebar_color #1d2021
+
+# Tab bar colors
 active_tab_background #1d2021
 active_tab_foreground #d5c4a1
 inactive_tab_background #3c3836
 inactive_tab_foreground #bdae93
 tab_bar_background #3c3836
-wayland_titlebar_color #1d2021
-macos_titlebar_color #1d2021
 
+# The 16 terminal colors
 # normal
 color0 #1d2021
 color1 #fb4934

--- a/colors/base16-gruvbox-dark-medium.conf
+++ b/colors/base16-gruvbox-dark-medium.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox dark, medium
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox dark, medium
+
 # Scheme name: base16 Gruvbox dark, medium
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282828
 foreground #d5c4a1
 selection_background #665c54
 selection_foreground #d5c4a1
-url_color #bdae93
+
+# Cursor colors
 cursor #d5c4a1
 cursor_text_color #282828
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #3c3836
+
+# OS Window titlebar colors
+wayland_titlebar_color #282828
+macos_titlebar_color #282828
+
+# Tab bar colors
 active_tab_background #282828
 active_tab_foreground #d5c4a1
 inactive_tab_background #3c3836
 inactive_tab_foreground #bdae93
 tab_bar_background #3c3836
-wayland_titlebar_color #282828
-macos_titlebar_color #282828
 
+# The 16 terminal colors
 # normal
 color0 #282828
 color1 #fb4934

--- a/colors/base16-gruvbox-dark-pale.conf
+++ b/colors/base16-gruvbox-dark-pale.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox dark, pale
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox dark, pale
+
 # Scheme name: base16 Gruvbox dark, pale
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #262626
 foreground #dab997
 selection_background #8a8a8a
 selection_foreground #dab997
-url_color #949494
+
+# Cursor colors
 cursor #dab997
 cursor_text_color #262626
+
+# URL underline color when hovering with mouse
+url_color #949494
+
+# Kitty window border colors
 active_border_color #8a8a8a
 inactive_border_color #3a3a3a
+
+# OS Window titlebar colors
+wayland_titlebar_color #262626
+macos_titlebar_color #262626
+
+# Tab bar colors
 active_tab_background #262626
 active_tab_foreground #dab997
 inactive_tab_background #3a3a3a
 inactive_tab_foreground #949494
 tab_bar_background #3a3a3a
-wayland_titlebar_color #262626
-macos_titlebar_color #262626
 
+# The 16 terminal colors
 # normal
 color0 #262626
 color1 #d75f5f

--- a/colors/base16-gruvbox-dark-soft.conf
+++ b/colors/base16-gruvbox-dark-soft.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox dark, soft
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox dark, soft
+
 # Scheme name: base16 Gruvbox dark, soft
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #32302f
 foreground #d5c4a1
 selection_background #665c54
 selection_foreground #d5c4a1
-url_color #bdae93
+
+# Cursor colors
 cursor #d5c4a1
 cursor_text_color #32302f
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #3c3836
+
+# OS Window titlebar colors
+wayland_titlebar_color #32302f
+macos_titlebar_color #32302f
+
+# Tab bar colors
 active_tab_background #32302f
 active_tab_foreground #d5c4a1
 inactive_tab_background #3c3836
 inactive_tab_foreground #bdae93
 tab_bar_background #3c3836
-wayland_titlebar_color #32302f
-macos_titlebar_color #32302f
 
+# The 16 terminal colors
 # normal
 color0 #32302f
 color1 #fb4934

--- a/colors/base16-gruvbox-light-hard.conf
+++ b/colors/base16-gruvbox-light-hard.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox light, hard
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox light, hard
+
 # Scheme name: base16 Gruvbox light, hard
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f9f5d7
 foreground #504945
 selection_background #bdae93
 selection_foreground #504945
-url_color #665c54
+
+# Cursor colors
 cursor #504945
 cursor_text_color #f9f5d7
+
+# URL underline color when hovering with mouse
+url_color #665c54
+
+# Kitty window border colors
 active_border_color #bdae93
 inactive_border_color #ebdbb2
+
+# OS Window titlebar colors
+wayland_titlebar_color #f9f5d7
+macos_titlebar_color #f9f5d7
+
+# Tab bar colors
 active_tab_background #f9f5d7
 active_tab_foreground #504945
 inactive_tab_background #ebdbb2
 inactive_tab_foreground #665c54
 tab_bar_background #ebdbb2
-wayland_titlebar_color #f9f5d7
-macos_titlebar_color #f9f5d7
 
+# The 16 terminal colors
 # normal
 color0 #f9f5d7
 color1 #9d0006

--- a/colors/base16-gruvbox-light-medium.conf
+++ b/colors/base16-gruvbox-light-medium.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox light, medium
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox light, medium
+
 # Scheme name: base16 Gruvbox light, medium
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbf1c7
 foreground #504945
 selection_background #bdae93
 selection_foreground #504945
-url_color #665c54
+
+# Cursor colors
 cursor #504945
 cursor_text_color #fbf1c7
+
+# URL underline color when hovering with mouse
+url_color #665c54
+
+# Kitty window border colors
 active_border_color #bdae93
 inactive_border_color #ebdbb2
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbf1c7
+macos_titlebar_color #fbf1c7
+
+# Tab bar colors
 active_tab_background #fbf1c7
 active_tab_foreground #504945
 inactive_tab_background #ebdbb2
 inactive_tab_foreground #665c54
 tab_bar_background #ebdbb2
-wayland_titlebar_color #fbf1c7
-macos_titlebar_color #fbf1c7
 
+# The 16 terminal colors
 # normal
 color0 #fbf1c7
 color1 #9d0006

--- a/colors/base16-gruvbox-light-soft.conf
+++ b/colors/base16-gruvbox-light-soft.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox light, soft
+## author:   Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox light, soft
+
 # Scheme name: base16 Gruvbox light, soft
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f2e5bc
 foreground #504945
 selection_background #bdae93
 selection_foreground #504945
-url_color #665c54
+
+# Cursor colors
 cursor #504945
 cursor_text_color #f2e5bc
+
+# URL underline color when hovering with mouse
+url_color #665c54
+
+# Kitty window border colors
 active_border_color #bdae93
 inactive_border_color #ebdbb2
+
+# OS Window titlebar colors
+wayland_titlebar_color #f2e5bc
+macos_titlebar_color #f2e5bc
+
+# Tab bar colors
 active_tab_background #f2e5bc
 active_tab_foreground #504945
 inactive_tab_background #ebdbb2
 inactive_tab_foreground #665c54
 tab_bar_background #ebdbb2
-wayland_titlebar_color #f2e5bc
-macos_titlebar_color #f2e5bc
 
+# The 16 terminal colors
 # normal
 color0 #f2e5bc
 color1 #9d0006

--- a/colors/base16-gruvbox-material-dark-hard.conf
+++ b/colors/base16-gruvbox-material-dark-hard.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Dark, Hard
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Dark, Hard
+
 # Scheme name: base16 Gruvbox Material Dark, Hard
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #202020
 foreground #ddc7a1
 selection_background #5a524c
 selection_foreground #ddc7a1
-url_color #bdae93
+
+# Cursor colors
 cursor #ddc7a1
 cursor_text_color #202020
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #5a524c
 inactive_border_color #2a2827
+
+# OS Window titlebar colors
+wayland_titlebar_color #202020
+macos_titlebar_color #202020
+
+# Tab bar colors
 active_tab_background #202020
 active_tab_foreground #ddc7a1
 inactive_tab_background #2a2827
 inactive_tab_foreground #bdae93
 tab_bar_background #2a2827
-wayland_titlebar_color #202020
-macos_titlebar_color #202020
 
+# The 16 terminal colors
 # normal
 color0 #202020
 color1 #ea6962

--- a/colors/base16-gruvbox-material-dark-medium.conf
+++ b/colors/base16-gruvbox-material-dark-medium.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Dark, Medium
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Dark, Medium
+
 # Scheme name: base16 Gruvbox Material Dark, Medium
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292828
 foreground #ddc7a1
 selection_background #665c54
 selection_foreground #ddc7a1
-url_color #bdae93
+
+# Cursor colors
 cursor #ddc7a1
 cursor_text_color #292828
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #32302f
+
+# OS Window titlebar colors
+wayland_titlebar_color #292828
+macos_titlebar_color #292828
+
+# Tab bar colors
 active_tab_background #292828
 active_tab_foreground #ddc7a1
 inactive_tab_background #32302f
 inactive_tab_foreground #bdae93
 tab_bar_background #32302f
-wayland_titlebar_color #292828
-macos_titlebar_color #292828
 
+# The 16 terminal colors
 # normal
 color0 #292828
 color1 #ea6962

--- a/colors/base16-gruvbox-material-dark-soft.conf
+++ b/colors/base16-gruvbox-material-dark-soft.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Dark, Soft
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Dark, Soft
+
 # Scheme name: base16 Gruvbox Material Dark, Soft
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #32302f
 foreground #ddc7a1
 selection_background #7c6f64
 selection_foreground #ddc7a1
-url_color #bdae93
+
+# Cursor colors
 cursor #ddc7a1
 cursor_text_color #32302f
+
+# URL underline color when hovering with mouse
+url_color #bdae93
+
+# Kitty window border colors
 active_border_color #7c6f64
 inactive_border_color #3c3836
+
+# OS Window titlebar colors
+wayland_titlebar_color #32302f
+macos_titlebar_color #32302f
+
+# Tab bar colors
 active_tab_background #32302f
 active_tab_foreground #ddc7a1
 inactive_tab_background #3c3836
 inactive_tab_foreground #bdae93
 tab_bar_background #3c3836
-wayland_titlebar_color #32302f
-macos_titlebar_color #32302f
 
+# The 16 terminal colors
 # normal
 color0 #32302f
 color1 #ea6962

--- a/colors/base16-gruvbox-material-light-hard.conf
+++ b/colors/base16-gruvbox-material-light-hard.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Light, Hard
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Light, Hard
+
 # Scheme name: base16 Gruvbox Material Light, Hard
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f9f5d7
 foreground #654735
 selection_background #a89984
 selection_foreground #654735
-url_color #c9b99a
+
+# Cursor colors
 cursor #654735
 cursor_text_color #f9f5d7
+
+# URL underline color when hovering with mouse
+url_color #c9b99a
+
+# Kitty window border colors
 active_border_color #a89984
 inactive_border_color #fbf1c7
+
+# OS Window titlebar colors
+wayland_titlebar_color #f9f5d7
+macos_titlebar_color #f9f5d7
+
+# Tab bar colors
 active_tab_background #f9f5d7
 active_tab_foreground #654735
 inactive_tab_background #fbf1c7
 inactive_tab_foreground #c9b99a
 tab_bar_background #fbf1c7
-wayland_titlebar_color #f9f5d7
-macos_titlebar_color #f9f5d7
 
+# The 16 terminal colors
 # normal
 color0 #f9f5d7
 color1 #c14a4a

--- a/colors/base16-gruvbox-material-light-medium.conf
+++ b/colors/base16-gruvbox-material-light-medium.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Light, Medium
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Light, Medium
+
 # Scheme name: base16 Gruvbox Material Light, Medium
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbf1c7
 foreground #654735
 selection_background #bdae93
 selection_foreground #654735
-url_color #665c54
+
+# Cursor colors
 cursor #654735
 cursor_text_color #fbf1c7
+
+# URL underline color when hovering with mouse
+url_color #665c54
+
+# Kitty window border colors
 active_border_color #bdae93
 inactive_border_color #f2e5bc
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbf1c7
+macos_titlebar_color #fbf1c7
+
+# Tab bar colors
 active_tab_background #fbf1c7
 active_tab_foreground #654735
 inactive_tab_background #f2e5bc
 inactive_tab_foreground #665c54
 tab_bar_background #f2e5bc
-wayland_titlebar_color #fbf1c7
-macos_titlebar_color #fbf1c7
 
+# The 16 terminal colors
 # normal
 color0 #fbf1c7
 color1 #c14a4a

--- a/colors/base16-gruvbox-material-light-soft.conf
+++ b/colors/base16-gruvbox-material-light-soft.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Gruvbox Material Light, Soft
+## author:   Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Gruvbox Material Light, Soft
+
 # Scheme name: base16 Gruvbox Material Light, Soft
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f2e5bc
 foreground #654735
 selection_background #a89984
 selection_foreground #654735
-url_color #665c54
+
+# Cursor colors
 cursor #654735
 cursor_text_color #f2e5bc
+
+# URL underline color when hovering with mouse
+url_color #665c54
+
+# Kitty window border colors
 active_border_color #a89984
 inactive_border_color #ebdbb2
+
+# OS Window titlebar colors
+wayland_titlebar_color #f2e5bc
+macos_titlebar_color #f2e5bc
+
+# Tab bar colors
 active_tab_background #f2e5bc
 active_tab_foreground #654735
 inactive_tab_background #ebdbb2
 inactive_tab_foreground #665c54
 tab_bar_background #ebdbb2
-wayland_titlebar_color #f2e5bc
-macos_titlebar_color #f2e5bc
 
+# The 16 terminal colors
 # normal
 color0 #f2e5bc
 color1 #c14a4a

--- a/colors/base16-hardcore.conf
+++ b/colors/base16-hardcore.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Hardcore
+## author:   Chris Caller
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Hardcore
+
 # Scheme name: base16 Hardcore
 # Scheme author: Chris Caller
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #212121
 foreground #cdcdcd
 selection_background #4a4a4a
 selection_foreground #cdcdcd
-url_color #707070
+
+# Cursor colors
 cursor #cdcdcd
 cursor_text_color #212121
+
+# URL underline color when hovering with mouse
+url_color #707070
+
+# Kitty window border colors
 active_border_color #4a4a4a
 inactive_border_color #303030
+
+# OS Window titlebar colors
+wayland_titlebar_color #212121
+macos_titlebar_color #212121
+
+# Tab bar colors
 active_tab_background #212121
 active_tab_foreground #cdcdcd
 inactive_tab_background #303030
 inactive_tab_foreground #707070
 tab_bar_background #303030
-wayland_titlebar_color #212121
-macos_titlebar_color #212121
 
+# The 16 terminal colors
 # normal
 color0 #212121
 color1 #f92672

--- a/colors/base16-harmonic16-dark.conf
+++ b/colors/base16-harmonic16-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Harmonic16 Dark
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Harmonic16 Dark
+
 # Scheme name: base16 Harmonic16 Dark
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0b1c2c
 foreground #cbd6e2
 selection_background #627e99
 selection_foreground #cbd6e2
-url_color #aabcce
+
+# Cursor colors
 cursor #cbd6e2
 cursor_text_color #0b1c2c
+
+# URL underline color when hovering with mouse
+url_color #aabcce
+
+# Kitty window border colors
 active_border_color #627e99
 inactive_border_color #223b54
+
+# OS Window titlebar colors
+wayland_titlebar_color #0b1c2c
+macos_titlebar_color #0b1c2c
+
+# Tab bar colors
 active_tab_background #0b1c2c
 active_tab_foreground #cbd6e2
 inactive_tab_background #223b54
 inactive_tab_foreground #aabcce
 tab_bar_background #223b54
-wayland_titlebar_color #0b1c2c
-macos_titlebar_color #0b1c2c
 
+# The 16 terminal colors
 # normal
 color0 #0b1c2c
 color1 #bf8b56

--- a/colors/base16-harmonic16-light.conf
+++ b/colors/base16-harmonic16-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Harmonic16 Light
+## author:   Jannik Siebert (https://github.com/janniks)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Harmonic16 Light
+
 # Scheme name: base16 Harmonic16 Light
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f7f9fb
 foreground #405c79
 selection_background #aabcce
 selection_foreground #405c79
-url_color #627e99
+
+# Cursor colors
 cursor #405c79
 cursor_text_color #f7f9fb
+
+# URL underline color when hovering with mouse
+url_color #627e99
+
+# Kitty window border colors
 active_border_color #aabcce
 inactive_border_color #e5ebf1
+
+# OS Window titlebar colors
+wayland_titlebar_color #f7f9fb
+macos_titlebar_color #f7f9fb
+
+# Tab bar colors
 active_tab_background #f7f9fb
 active_tab_foreground #405c79
 inactive_tab_background #e5ebf1
 inactive_tab_foreground #627e99
 tab_bar_background #e5ebf1
-wayland_titlebar_color #f7f9fb
-macos_titlebar_color #f7f9fb
 
+# The 16 terminal colors
 # normal
 color0 #f7f9fb
 color1 #bf8b56

--- a/colors/base16-heetch-light.conf
+++ b/colors/base16-heetch-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Heetch Light
+## author:   Geoffrey Teale (tealeg@gmail.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Heetch Light
+
 # Scheme name: base16 Heetch Light
 # Scheme author: Geoffrey Teale (tealeg@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #feffff
 foreground #5a496e
 selection_background #9c92a8
 selection_foreground #5a496e
-url_color #ddd6e5
+
+# Cursor colors
 cursor #5a496e
 cursor_text_color #feffff
+
+# URL underline color when hovering with mouse
+url_color #ddd6e5
+
+# Kitty window border colors
 active_border_color #9c92a8
 inactive_border_color #392551
+
+# OS Window titlebar colors
+wayland_titlebar_color #feffff
+macos_titlebar_color #feffff
+
+# Tab bar colors
 active_tab_background #feffff
 active_tab_foreground #5a496e
 inactive_tab_background #392551
 inactive_tab_foreground #ddd6e5
 tab_bar_background #392551
-wayland_titlebar_color #feffff
-macos_titlebar_color #feffff
 
+# The 16 terminal colors
 # normal
 color0 #feffff
 color1 #27d9d5

--- a/colors/base16-heetch.conf
+++ b/colors/base16-heetch.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Heetch Dark
+## author:   Geoffrey Teale (tealeg@gmail.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Heetch Dark
+
 # Scheme name: base16 Heetch Dark
 # Scheme author: Geoffrey Teale (tealeg@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #190134
 foreground #bdb6c5
 selection_background #7b6d8b
 selection_foreground #bdb6c5
-url_color #9c92a8
+
+# Cursor colors
 cursor #bdb6c5
 cursor_text_color #190134
+
+# URL underline color when hovering with mouse
+url_color #9c92a8
+
+# Kitty window border colors
 active_border_color #7b6d8b
 inactive_border_color #392551
+
+# OS Window titlebar colors
+wayland_titlebar_color #190134
+macos_titlebar_color #190134
+
+# Tab bar colors
 active_tab_background #190134
 active_tab_foreground #bdb6c5
 inactive_tab_background #392551
 inactive_tab_foreground #9c92a8
 tab_bar_background #392551
-wayland_titlebar_color #190134
-macos_titlebar_color #190134
 
+# The 16 terminal colors
 # normal
 color0 #190134
 color1 #27d9d5

--- a/colors/base16-helios.conf
+++ b/colors/base16-helios.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Helios
+## author:   Alex Meyer (https://github.com/reyemxela)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Helios
+
 # Scheme name: base16 Helios
 # Scheme author: Alex Meyer (https://github.com/reyemxela)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1d2021
 foreground #d5d5d5
 selection_background #6f7579
 selection_foreground #d5d5d5
-url_color #cdcdcd
+
+# Cursor colors
 cursor #d5d5d5
 cursor_text_color #1d2021
+
+# URL underline color when hovering with mouse
+url_color #cdcdcd
+
+# Kitty window border colors
 active_border_color #6f7579
 inactive_border_color #383c3e
+
+# OS Window titlebar colors
+wayland_titlebar_color #1d2021
+macos_titlebar_color #1d2021
+
+# Tab bar colors
 active_tab_background #1d2021
 active_tab_foreground #d5d5d5
 inactive_tab_background #383c3e
 inactive_tab_foreground #cdcdcd
 tab_bar_background #383c3e
-wayland_titlebar_color #1d2021
-macos_titlebar_color #1d2021
 
+# The 16 terminal colors
 # normal
 color0 #1d2021
 color1 #d72638

--- a/colors/base16-hopscotch.conf
+++ b/colors/base16-hopscotch.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Hopscotch
+## author:   Jan T. Sott
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Hopscotch
+
 # Scheme name: base16 Hopscotch
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #322931
 foreground #b9b5b8
 selection_background #797379
 selection_foreground #b9b5b8
-url_color #989498
+
+# Cursor colors
 cursor #b9b5b8
 cursor_text_color #322931
+
+# URL underline color when hovering with mouse
+url_color #989498
+
+# Kitty window border colors
 active_border_color #797379
 inactive_border_color #433b42
+
+# OS Window titlebar colors
+wayland_titlebar_color #322931
+macos_titlebar_color #322931
+
+# Tab bar colors
 active_tab_background #322931
 active_tab_foreground #b9b5b8
 inactive_tab_background #433b42
 inactive_tab_foreground #989498
 tab_bar_background #433b42
-wayland_titlebar_color #322931
-macos_titlebar_color #322931
 
+# The 16 terminal colors
 # normal
 color0 #322931
 color1 #dd464c

--- a/colors/base16-horizon-dark.conf
+++ b/colors/base16-horizon-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Horizon Dark
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Horizon Dark
+
 # Scheme name: base16 Horizon Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1e26
 foreground #cbced0
 selection_background #6f6f70
 selection_foreground #cbced0
-url_color #9da0a2
+
+# Cursor colors
 cursor #cbced0
 cursor_text_color #1c1e26
+
+# URL underline color when hovering with mouse
+url_color #9da0a2
+
+# Kitty window border colors
 active_border_color #6f6f70
 inactive_border_color #232530
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1e26
+macos_titlebar_color #1c1e26
+
+# Tab bar colors
 active_tab_background #1c1e26
 active_tab_foreground #cbced0
 inactive_tab_background #232530
 inactive_tab_foreground #9da0a2
 tab_bar_background #232530
-wayland_titlebar_color #1c1e26
-macos_titlebar_color #1c1e26
 
+# The 16 terminal colors
 # normal
 color0 #1c1e26
 color1 #e93c58

--- a/colors/base16-horizon-light.conf
+++ b/colors/base16-horizon-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Horizon Light
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Horizon Light
+
 # Scheme name: base16 Horizon Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fdf0ed
 foreground #403c3d
 selection_background #bdb3b1
 selection_foreground #403c3d
-url_color #948c8a
+
+# Cursor colors
 cursor #403c3d
 cursor_text_color #fdf0ed
+
+# URL underline color when hovering with mouse
+url_color #948c8a
+
+# Kitty window border colors
 active_border_color #bdb3b1
 inactive_border_color #fadad1
+
+# OS Window titlebar colors
+wayland_titlebar_color #fdf0ed
+macos_titlebar_color #fdf0ed
+
+# Tab bar colors
 active_tab_background #fdf0ed
 active_tab_foreground #403c3d
 inactive_tab_background #fadad1
 inactive_tab_foreground #948c8a
 tab_bar_background #fadad1
-wayland_titlebar_color #fdf0ed
-macos_titlebar_color #fdf0ed
 
+# The 16 terminal colors
 # normal
 color0 #fdf0ed
 color1 #f7939b

--- a/colors/base16-horizon-terminal-dark.conf
+++ b/colors/base16-horizon-terminal-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Horizon Terminal Dark
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Horizon Terminal Dark
+
 # Scheme name: base16 Horizon Terminal Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1e26
 foreground #cbced0
 selection_background #6f6f70
 selection_foreground #cbced0
-url_color #9da0a2
+
+# Cursor colors
 cursor #cbced0
 cursor_text_color #1c1e26
+
+# URL underline color when hovering with mouse
+url_color #9da0a2
+
+# Kitty window border colors
 active_border_color #6f6f70
 inactive_border_color #232530
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1e26
+macos_titlebar_color #1c1e26
+
+# Tab bar colors
 active_tab_background #1c1e26
 active_tab_foreground #cbced0
 inactive_tab_background #232530
 inactive_tab_foreground #9da0a2
 tab_bar_background #232530
-wayland_titlebar_color #1c1e26
-macos_titlebar_color #1c1e26
 
+# The 16 terminal colors
 # normal
 color0 #1c1e26
 color1 #e95678

--- a/colors/base16-horizon-terminal-light.conf
+++ b/colors/base16-horizon-terminal-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Horizon Terminal Light
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Horizon Terminal Light
+
 # Scheme name: base16 Horizon Terminal Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fdf0ed
 foreground #403c3d
 selection_background #bdb3b1
 selection_foreground #403c3d
-url_color #948c8a
+
+# Cursor colors
 cursor #403c3d
 cursor_text_color #fdf0ed
+
+# URL underline color when hovering with mouse
+url_color #948c8a
+
+# Kitty window border colors
 active_border_color #bdb3b1
 inactive_border_color #fadad1
+
+# OS Window titlebar colors
+wayland_titlebar_color #fdf0ed
+macos_titlebar_color #fdf0ed
+
+# Tab bar colors
 active_tab_background #fdf0ed
 active_tab_foreground #403c3d
 inactive_tab_background #fadad1
 inactive_tab_foreground #948c8a
 tab_bar_background #fadad1
-wayland_titlebar_color #fdf0ed
-macos_titlebar_color #fdf0ed
 
+# The 16 terminal colors
 # normal
 color0 #fdf0ed
 color1 #e95678

--- a/colors/base16-humanoid-dark.conf
+++ b/colors/base16-humanoid-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Humanoid dark
+## author:   Thomas (tasmo) Friese
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Humanoid dark
+
 # Scheme name: base16 Humanoid dark
 # Scheme author: Thomas (tasmo) Friese
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #232629
 foreground #f8f8f2
 selection_background #60615d
 selection_foreground #f8f8f2
-url_color #c0c0bd
+
+# Cursor colors
 cursor #f8f8f2
 cursor_text_color #232629
+
+# URL underline color when hovering with mouse
+url_color #c0c0bd
+
+# Kitty window border colors
 active_border_color #60615d
 inactive_border_color #333b3d
+
+# OS Window titlebar colors
+wayland_titlebar_color #232629
+macos_titlebar_color #232629
+
+# Tab bar colors
 active_tab_background #232629
 active_tab_foreground #f8f8f2
 inactive_tab_background #333b3d
 inactive_tab_foreground #c0c0bd
 tab_bar_background #333b3d
-wayland_titlebar_color #232629
-macos_titlebar_color #232629
 
+# The 16 terminal colors
 # normal
 color0 #232629
 color1 #f11235

--- a/colors/base16-humanoid-light.conf
+++ b/colors/base16-humanoid-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Humanoid light
+## author:   Thomas (tasmo) Friese
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Humanoid light
+
 # Scheme name: base16 Humanoid light
 # Scheme author: Thomas (tasmo) Friese
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f8f8f2
 foreground #232629
 selection_background #c0c0bd
 selection_foreground #232629
-url_color #60615d
+
+# Cursor colors
 cursor #232629
 cursor_text_color #f8f8f2
+
+# URL underline color when hovering with mouse
+url_color #60615d
+
+# Kitty window border colors
 active_border_color #c0c0bd
 inactive_border_color #efefe9
+
+# OS Window titlebar colors
+wayland_titlebar_color #f8f8f2
+macos_titlebar_color #f8f8f2
+
+# Tab bar colors
 active_tab_background #f8f8f2
 active_tab_foreground #232629
 inactive_tab_background #efefe9
 inactive_tab_foreground #60615d
 tab_bar_background #efefe9
-wayland_titlebar_color #f8f8f2
-macos_titlebar_color #f8f8f2
 
+# The 16 terminal colors
 # normal
 color0 #f8f8f2
 color1 #b0151a

--- a/colors/base16-ia-dark.conf
+++ b/colors/base16-ia-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 iA Dark
+## author:   iA Inc. (modified by aramisgithub)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    iA Dark
+
 # Scheme name: base16 iA Dark
 # Scheme author: iA Inc. (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1a1a1a
 foreground #cccccc
 selection_background #767676
 selection_foreground #cccccc
-url_color #b8b8b8
+
+# Cursor colors
 cursor #cccccc
 cursor_text_color #1a1a1a
+
+# URL underline color when hovering with mouse
+url_color #b8b8b8
+
+# Kitty window border colors
 active_border_color #767676
 inactive_border_color #222222
+
+# OS Window titlebar colors
+wayland_titlebar_color #1a1a1a
+macos_titlebar_color #1a1a1a
+
+# Tab bar colors
 active_tab_background #1a1a1a
 active_tab_foreground #cccccc
 inactive_tab_background #222222
 inactive_tab_foreground #b8b8b8
 tab_bar_background #222222
-wayland_titlebar_color #1a1a1a
-macos_titlebar_color #1a1a1a
 
+# The 16 terminal colors
 # normal
 color0 #1a1a1a
 color1 #d88568

--- a/colors/base16-ia-light.conf
+++ b/colors/base16-ia-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 iA Light
+## author:   iA Inc. (modified by aramisgithub)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    iA Light
+
 # Scheme name: base16 iA Light
 # Scheme author: iA Inc. (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f6f6f6
 foreground #181818
 selection_background #898989
 selection_foreground #181818
-url_color #767676
+
+# Cursor colors
 cursor #181818
 cursor_text_color #f6f6f6
+
+# URL underline color when hovering with mouse
+url_color #767676
+
+# Kitty window border colors
 active_border_color #898989
 inactive_border_color #dedede
+
+# OS Window titlebar colors
+wayland_titlebar_color #f6f6f6
+macos_titlebar_color #f6f6f6
+
+# Tab bar colors
 active_tab_background #f6f6f6
 active_tab_foreground #181818
 inactive_tab_background #dedede
 inactive_tab_foreground #767676
 tab_bar_background #dedede
-wayland_titlebar_color #f6f6f6
-macos_titlebar_color #f6f6f6
 
+# The 16 terminal colors
 # normal
 color0 #f6f6f6
 color1 #9c5a02

--- a/colors/base16-icy.conf
+++ b/colors/base16-icy.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Icy Dark
+## author:   icyphox (https://icyphox.ga)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Icy Dark
+
 # Scheme name: base16 Icy Dark
 # Scheme author: icyphox (https://icyphox.ga)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #021012
 foreground #095b67
 selection_background #052e34
 selection_foreground #095b67
-url_color #064048
+
+# Cursor colors
 cursor #095b67
 cursor_text_color #021012
+
+# URL underline color when hovering with mouse
+url_color #064048
+
+# Kitty window border colors
 active_border_color #052e34
 inactive_border_color #031619
+
+# OS Window titlebar colors
+wayland_titlebar_color #021012
+macos_titlebar_color #021012
+
+# Tab bar colors
 active_tab_background #021012
 active_tab_foreground #095b67
 inactive_tab_background #031619
 inactive_tab_foreground #064048
 tab_bar_background #031619
-wayland_titlebar_color #021012
-macos_titlebar_color #021012
 
+# The 16 terminal colors
 # normal
 color0 #021012
 color1 #16c1d9

--- a/colors/base16-irblack.conf
+++ b/colors/base16-irblack.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 IR Black
+## author:   Timothée Poisot (http://timotheepoisot.fr)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    IR Black
+
 # Scheme name: base16 IR Black
 # Scheme author: Timothée Poisot (http://timotheepoisot.fr)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #b5b3aa
 selection_background #6c6c66
 selection_foreground #b5b3aa
-url_color #918f88
+
+# Cursor colors
 cursor #b5b3aa
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #918f88
+
+# Kitty window border colors
 active_border_color #6c6c66
 inactive_border_color #242422
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #b5b3aa
 inactive_tab_background #242422
 inactive_tab_foreground #918f88
 tab_bar_background #242422
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #ff6c60

--- a/colors/base16-isotope.conf
+++ b/colors/base16-isotope.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Isotope
+## author:   Jan T. Sott
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Isotope
+
 # Scheme name: base16 Isotope
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #d0d0d0
 selection_background #808080
 selection_foreground #d0d0d0
-url_color #c0c0c0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #c0c0c0
+
+# Kitty window border colors
 active_border_color #808080
 inactive_border_color #404040
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #d0d0d0
 inactive_tab_background #404040
 inactive_tab_foreground #c0c0c0
 tab_bar_background #404040
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #ff0000

--- a/colors/base16-jabuti.conf
+++ b/colors/base16-jabuti.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Jabuti
+## author:   https://github.com/notusknot
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Jabuti
+
 # Scheme name: base16 Jabuti
 # Scheme author: https://github.com/notusknot
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292a37
 foreground #c0cbe3
 selection_background #45475d
 selection_foreground #c0cbe3
-url_color #50526b
+
+# Cursor colors
 cursor #c0cbe3
 cursor_text_color #292a37
+
+# URL underline color when hovering with mouse
+url_color #50526b
+
+# Kitty window border colors
 active_border_color #45475d
 inactive_border_color #343545
+
+# OS Window titlebar colors
+wayland_titlebar_color #292a37
+macos_titlebar_color #292a37
+
+# Tab bar colors
 active_tab_background #292a37
 active_tab_foreground #c0cbe3
 inactive_tab_background #343545
 inactive_tab_foreground #50526b
 tab_bar_background #343545
-wayland_titlebar_color #292a37
-macos_titlebar_color #292a37
 
+# The 16 terminal colors
 # normal
 color0 #292a37
 color1 #ec6a88

--- a/colors/base16-kanagawa.conf
+++ b/colors/base16-kanagawa.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Kanagawa
+## author:   Tommaso Laurenzi (https://github.com/rebelot)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Kanagawa
+
 # Scheme name: base16 Kanagawa
 # Scheme author: Tommaso Laurenzi (https://github.com/rebelot)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1f1f28
 foreground #dcd7ba
 selection_background #54546d
 selection_foreground #dcd7ba
-url_color #727169
+
+# Cursor colors
 cursor #dcd7ba
 cursor_text_color #1f1f28
+
+# URL underline color when hovering with mouse
+url_color #727169
+
+# Kitty window border colors
 active_border_color #54546d
 inactive_border_color #16161d
+
+# OS Window titlebar colors
+wayland_titlebar_color #1f1f28
+macos_titlebar_color #1f1f28
+
+# Tab bar colors
 active_tab_background #1f1f28
 active_tab_foreground #dcd7ba
 inactive_tab_background #16161d
 inactive_tab_foreground #727169
 tab_bar_background #16161d
-wayland_titlebar_color #1f1f28
-macos_titlebar_color #1f1f28
 
+# The 16 terminal colors
 # normal
 color0 #1f1f28
 color1 #c34043

--- a/colors/base16-katy.conf
+++ b/colors/base16-katy.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Katy
+## author:   George Essig (https://github.com/gessig)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Katy
+
 # Scheme name: base16 Katy
 # Scheme author: George Essig (https://github.com/gessig)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292d3e
 foreground #959dcb
 selection_background #676e95
 selection_foreground #959dcb
-url_color #8796b0
+
+# Cursor colors
 cursor #959dcb
 cursor_text_color #292d3e
+
+# URL underline color when hovering with mouse
+url_color #8796b0
+
+# Kitty window border colors
 active_border_color #676e95
 inactive_border_color #444267
+
+# OS Window titlebar colors
+wayland_titlebar_color #292d3e
+macos_titlebar_color #292d3e
+
+# Tab bar colors
 active_tab_background #292d3e
 active_tab_foreground #959dcb
 inactive_tab_background #444267
 inactive_tab_foreground #8796b0
 tab_bar_background #444267
-wayland_titlebar_color #292d3e
-macos_titlebar_color #292d3e
 
+# The 16 terminal colors
 # normal
 color0 #292d3e
 color1 #6e98e1

--- a/colors/base16-kimber.conf
+++ b/colors/base16-kimber.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Kimber
+## author:   Mishka Nguyen (https://github.com/akhsiM)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Kimber
+
 # Scheme name: base16 Kimber
 # Scheme author: Mishka Nguyen (https://github.com/akhsiM)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #222222
 foreground #dedee7
 selection_background #644646
 selection_foreground #dedee7
-url_color #5a5a5a
+
+# Cursor colors
 cursor #dedee7
 cursor_text_color #222222
+
+# URL underline color when hovering with mouse
+url_color #5a5a5a
+
+# Kitty window border colors
 active_border_color #644646
 inactive_border_color #313131
+
+# OS Window titlebar colors
+wayland_titlebar_color #222222
+macos_titlebar_color #222222
+
+# Tab bar colors
 active_tab_background #222222
 active_tab_foreground #dedee7
 inactive_tab_background #313131
 inactive_tab_foreground #5a5a5a
 tab_bar_background #313131
-wayland_titlebar_color #222222
-macos_titlebar_color #222222
 
+# The 16 terminal colors
 # normal
 color0 #222222
 color1 #c88c8c

--- a/colors/base16-lime.conf
+++ b/colors/base16-lime.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 lime
+## author:   limelier
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    lime
+
 # Scheme name: base16 lime
 # Scheme author: limelier
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1a1a2f
 foreground #818175
 selection_background #313140
 selection_foreground #818175
-url_color #515155
+
+# Cursor colors
 cursor #818175
 cursor_text_color #1a1a2f
+
+# URL underline color when hovering with mouse
+url_color #515155
+
+# Kitty window border colors
 active_border_color #313140
 inactive_border_color #202030
+
+# OS Window titlebar colors
+wayland_titlebar_color #1a1a2f
+macos_titlebar_color #1a1a2f
+
+# Tab bar colors
 active_tab_background #1a1a2f
 active_tab_foreground #818175
 inactive_tab_background #202030
 inactive_tab_foreground #515155
 tab_bar_background #202030
-wayland_titlebar_color #1a1a2f
-macos_titlebar_color #1a1a2f
 
+# The 16 terminal colors
 # normal
 color0 #1a1a2f
 color1 #ff662a

--- a/colors/base16-macintosh.conf
+++ b/colors/base16-macintosh.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Macintosh
+## author:   Rebecca Bettencourt (http://www.kreativekorp.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Macintosh
+
 # Scheme name: base16 Macintosh
 # Scheme author: Rebecca Bettencourt (http://www.kreativekorp.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c0c0c0
 selection_background #808080
 selection_foreground #c0c0c0
-url_color #808080
+
+# Cursor colors
 cursor #c0c0c0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #808080
+
+# Kitty window border colors
 active_border_color #808080
 inactive_border_color #404040
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c0c0c0
 inactive_tab_background #404040
 inactive_tab_foreground #808080
 tab_bar_background #404040
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #dd0907

--- a/colors/base16-marrakesh.conf
+++ b/colors/base16-marrakesh.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Marrakesh
+## author:   Alexandre Gavioli (http://github.com/Alexx2/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Marrakesh
+
 # Scheme name: base16 Marrakesh
 # Scheme author: Alexandre Gavioli (http://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #201602
 foreground #948e48
 selection_background #6c6823
 selection_foreground #948e48
-url_color #86813b
+
+# Cursor colors
 cursor #948e48
 cursor_text_color #201602
+
+# URL underline color when hovering with mouse
+url_color #86813b
+
+# Kitty window border colors
 active_border_color #6c6823
 inactive_border_color #302e00
+
+# OS Window titlebar colors
+wayland_titlebar_color #201602
+macos_titlebar_color #201602
+
+# Tab bar colors
 active_tab_background #201602
 active_tab_foreground #948e48
 inactive_tab_background #302e00
 inactive_tab_foreground #86813b
 tab_bar_background #302e00
-wayland_titlebar_color #201602
-macos_titlebar_color #201602
 
+# The 16 terminal colors
 # normal
 color0 #201602
 color1 #c35359

--- a/colors/base16-materia.conf
+++ b/colors/base16-materia.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Materia
+## author:   Defman21
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Materia
+
 # Scheme name: base16 Materia
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #263238
 foreground #cdd3de
 selection_background #707880
 selection_foreground #cdd3de
-url_color #c9ccd3
+
+# Cursor colors
 cursor #cdd3de
 cursor_text_color #263238
+
+# URL underline color when hovering with mouse
+url_color #c9ccd3
+
+# Kitty window border colors
 active_border_color #707880
 inactive_border_color #2c393f
+
+# OS Window titlebar colors
+wayland_titlebar_color #263238
+macos_titlebar_color #263238
+
+# Tab bar colors
 active_tab_background #263238
 active_tab_foreground #cdd3de
 inactive_tab_background #2c393f
 inactive_tab_foreground #c9ccd3
 tab_bar_background #2c393f
-wayland_titlebar_color #263238
-macos_titlebar_color #263238
 
+# The 16 terminal colors
 # normal
 color0 #263238
 color1 #ec5f67

--- a/colors/base16-material-darker.conf
+++ b/colors/base16-material-darker.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Material Darker
+## author:   Nate Peterson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Material Darker
+
 # Scheme name: base16 Material Darker
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #212121
 foreground #eeffff
 selection_background #4a4a4a
 selection_foreground #eeffff
-url_color #b2ccd6
+
+# Cursor colors
 cursor #eeffff
 cursor_text_color #212121
+
+# URL underline color when hovering with mouse
+url_color #b2ccd6
+
+# Kitty window border colors
 active_border_color #4a4a4a
 inactive_border_color #303030
+
+# OS Window titlebar colors
+wayland_titlebar_color #212121
+macos_titlebar_color #212121
+
+# Tab bar colors
 active_tab_background #212121
 active_tab_foreground #eeffff
 inactive_tab_background #303030
 inactive_tab_foreground #b2ccd6
 tab_bar_background #303030
-wayland_titlebar_color #212121
-macos_titlebar_color #212121
 
+# The 16 terminal colors
 # normal
 color0 #212121
 color1 #f07178

--- a/colors/base16-material-lighter.conf
+++ b/colors/base16-material-lighter.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Material Lighter
+## author:   Nate Peterson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Material Lighter
+
 # Scheme name: base16 Material Lighter
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fafafa
 foreground #80cbc4
 selection_background #ccd7da
 selection_foreground #80cbc4
-url_color #8796b0
+
+# Cursor colors
 cursor #80cbc4
 cursor_text_color #fafafa
+
+# URL underline color when hovering with mouse
+url_color #8796b0
+
+# Kitty window border colors
 active_border_color #ccd7da
 inactive_border_color #e7eaec
+
+# OS Window titlebar colors
+wayland_titlebar_color #fafafa
+macos_titlebar_color #fafafa
+
+# Tab bar colors
 active_tab_background #fafafa
 active_tab_foreground #80cbc4
 inactive_tab_background #e7eaec
 inactive_tab_foreground #8796b0
 tab_bar_background #e7eaec
-wayland_titlebar_color #fafafa
-macos_titlebar_color #fafafa
 
+# The 16 terminal colors
 # normal
 color0 #fafafa
 color1 #ff5370

--- a/colors/base16-material-palenight.conf
+++ b/colors/base16-material-palenight.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Material Palenight
+## author:   Nate Peterson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Material Palenight
+
 # Scheme name: base16 Material Palenight
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292d3e
 foreground #959dcb
 selection_background #676e95
 selection_foreground #959dcb
-url_color #8796b0
+
+# Cursor colors
 cursor #959dcb
 cursor_text_color #292d3e
+
+# URL underline color when hovering with mouse
+url_color #8796b0
+
+# Kitty window border colors
 active_border_color #676e95
 inactive_border_color #444267
+
+# OS Window titlebar colors
+wayland_titlebar_color #292d3e
+macos_titlebar_color #292d3e
+
+# Tab bar colors
 active_tab_background #292d3e
 active_tab_foreground #959dcb
 inactive_tab_background #444267
 inactive_tab_foreground #8796b0
 tab_bar_background #444267
-wayland_titlebar_color #292d3e
-macos_titlebar_color #292d3e
 
+# The 16 terminal colors
 # normal
 color0 #292d3e
 color1 #f07178

--- a/colors/base16-material-vivid.conf
+++ b/colors/base16-material-vivid.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Material Vivid
+## author:   joshyrobot
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Material Vivid
+
 # Scheme name: base16 Material Vivid
 # Scheme author: joshyrobot
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #202124
 foreground #80868b
 selection_background #44464d
 selection_foreground #80868b
-url_color #676c71
+
+# Cursor colors
 cursor #80868b
 cursor_text_color #202124
+
+# URL underline color when hovering with mouse
+url_color #676c71
+
+# Kitty window border colors
 active_border_color #44464d
 inactive_border_color #27292c
+
+# OS Window titlebar colors
+wayland_titlebar_color #202124
+macos_titlebar_color #202124
+
+# Tab bar colors
 active_tab_background #202124
 active_tab_foreground #80868b
 inactive_tab_background #27292c
 inactive_tab_foreground #676c71
 tab_bar_background #27292c
-wayland_titlebar_color #202124
-macos_titlebar_color #202124
 
+# The 16 terminal colors
 # normal
 color0 #202124
 color1 #f44336

--- a/colors/base16-material.conf
+++ b/colors/base16-material.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Material
+## author:   Nate Peterson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Material
+
 # Scheme name: base16 Material
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #263238
 foreground #eeffff
 selection_background #546e7a
 selection_foreground #eeffff
-url_color #b2ccd6
+
+# Cursor colors
 cursor #eeffff
 cursor_text_color #263238
+
+# URL underline color when hovering with mouse
+url_color #b2ccd6
+
+# Kitty window border colors
 active_border_color #546e7a
 inactive_border_color #2e3c43
+
+# OS Window titlebar colors
+wayland_titlebar_color #263238
+macos_titlebar_color #263238
+
+# Tab bar colors
 active_tab_background #263238
 active_tab_foreground #eeffff
 inactive_tab_background #2e3c43
 inactive_tab_foreground #b2ccd6
 tab_bar_background #2e3c43
-wayland_titlebar_color #263238
-macos_titlebar_color #263238
 
+# The 16 terminal colors
 # normal
 color0 #263238
 color1 #f07178

--- a/colors/base16-measured-dark.conf
+++ b/colors/base16-measured-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Measured Dark
+## author:   Measured (https://measured.co)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Measured Dark
+
 # Scheme name: base16 Measured Dark
 # Scheme author: Measured (https://measured.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #00211f
 foreground #dcdcdc
 selection_background #ababab
 selection_foreground #dcdcdc
-url_color #c3c3c3
+
+# Cursor colors
 cursor #dcdcdc
 cursor_text_color #00211f
+
+# URL underline color when hovering with mouse
+url_color #c3c3c3
+
+# Kitty window border colors
 active_border_color #ababab
 inactive_border_color #003a38
+
+# OS Window titlebar colors
+wayland_titlebar_color #00211f
+macos_titlebar_color #00211f
+
+# Tab bar colors
 active_tab_background #00211f
 active_tab_foreground #dcdcdc
 inactive_tab_background #003a38
 inactive_tab_foreground #c3c3c3
 tab_bar_background #003a38
-wayland_titlebar_color #00211f
-macos_titlebar_color #00211f
 
+# The 16 terminal colors
 # normal
 color0 #00211f
 color1 #ce7e8e

--- a/colors/base16-measured-light.conf
+++ b/colors/base16-measured-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Measured Light
+## author:   Measured (https://measured.co)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Measured Light
+
 # Scheme name: base16 Measured Light
 # Scheme author: Measured (https://measured.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fdf9f5
 foreground #292929
 selection_background #5a5a5a
 selection_foreground #292929
-url_color #404040
+
+# Cursor colors
 cursor #292929
 cursor_text_color #fdf9f5
+
+# URL underline color when hovering with mouse
+url_color #404040
+
+# Kitty window border colors
 active_border_color #5a5a5a
 inactive_border_color #f9f5f1
+
+# OS Window titlebar colors
+wayland_titlebar_color #fdf9f5
+macos_titlebar_color #fdf9f5
+
+# Tab bar colors
 active_tab_background #fdf9f5
 active_tab_foreground #292929
 inactive_tab_background #f9f5f1
 inactive_tab_foreground #404040
 tab_bar_background #f9f5f1
-wayland_titlebar_color #fdf9f5
-macos_titlebar_color #fdf9f5
 
+# The 16 terminal colors
 # normal
 color0 #fdf9f5
 color1 #ac1f35

--- a/colors/base16-mellow-purple.conf
+++ b/colors/base16-mellow-purple.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Mellow Purple
+## author:   gidsi
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Mellow Purple
+
 # Scheme name: base16 Mellow Purple
 # Scheme author: gidsi
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1e0528
 foreground #ffeeff
 selection_background #320f55
 selection_foreground #ffeeff
-url_color #873582
+
+# Cursor colors
 cursor #ffeeff
 cursor_text_color #1e0528
+
+# URL underline color when hovering with mouse
+url_color #873582
+
+# Kitty window border colors
 active_border_color #320f55
 inactive_border_color #1a092d
+
+# OS Window titlebar colors
+wayland_titlebar_color #1e0528
+macos_titlebar_color #1e0528
+
+# Tab bar colors
 active_tab_background #1e0528
 active_tab_foreground #ffeeff
 inactive_tab_background #1a092d
 inactive_tab_foreground #873582
 tab_bar_background #1a092d
-wayland_titlebar_color #1e0528
-macos_titlebar_color #1e0528
 
+# The 16 terminal colors
 # normal
 color0 #1e0528
 color1 #00d9e9

--- a/colors/base16-mexico-light.conf
+++ b/colors/base16-mexico-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Mexico Light
+## author:   Sheldon Johnson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Mexico Light
+
 # Scheme name: base16 Mexico Light
 # Scheme author: Sheldon Johnson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f8f8f8
 foreground #383838
 selection_background #b8b8b8
 selection_foreground #383838
-url_color #585858
+
+# Cursor colors
 cursor #383838
 cursor_text_color #f8f8f8
+
+# URL underline color when hovering with mouse
+url_color #585858
+
+# Kitty window border colors
 active_border_color #b8b8b8
 inactive_border_color #e8e8e8
+
+# OS Window titlebar colors
+wayland_titlebar_color #f8f8f8
+macos_titlebar_color #f8f8f8
+
+# Tab bar colors
 active_tab_background #f8f8f8
 active_tab_foreground #383838
 inactive_tab_background #e8e8e8
 inactive_tab_foreground #585858
 tab_bar_background #e8e8e8
-wayland_titlebar_color #f8f8f8
-macos_titlebar_color #f8f8f8
 
+# The 16 terminal colors
 # normal
 color0 #f8f8f8
 color1 #ab4642

--- a/colors/base16-mocha.conf
+++ b/colors/base16-mocha.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Mocha
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Mocha
+
 # Scheme name: base16 Mocha
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #3b3228
 foreground #d0c8c6
 selection_background #7e705a
 selection_foreground #d0c8c6
-url_color #b8afad
+
+# Cursor colors
 cursor #d0c8c6
 cursor_text_color #3b3228
+
+# URL underline color when hovering with mouse
+url_color #b8afad
+
+# Kitty window border colors
 active_border_color #7e705a
 inactive_border_color #534636
+
+# OS Window titlebar colors
+wayland_titlebar_color #3b3228
+macos_titlebar_color #3b3228
+
+# Tab bar colors
 active_tab_background #3b3228
 active_tab_foreground #d0c8c6
 inactive_tab_background #534636
 inactive_tab_foreground #b8afad
 tab_bar_background #534636
-wayland_titlebar_color #3b3228
-macos_titlebar_color #3b3228
 
+# The 16 terminal colors
 # normal
 color0 #3b3228
 color1 #cb6077

--- a/colors/base16-monokai.conf
+++ b/colors/base16-monokai.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Monokai
+## author:   Wimer Hazenberg (http://www.monokai.nl)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Monokai
+
 # Scheme name: base16 Monokai
 # Scheme author: Wimer Hazenberg (http://www.monokai.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #272822
 foreground #f8f8f2
 selection_background #75715e
 selection_foreground #f8f8f2
-url_color #a59f85
+
+# Cursor colors
 cursor #f8f8f2
 cursor_text_color #272822
+
+# URL underline color when hovering with mouse
+url_color #a59f85
+
+# Kitty window border colors
 active_border_color #75715e
 inactive_border_color #383830
+
+# OS Window titlebar colors
+wayland_titlebar_color #272822
+macos_titlebar_color #272822
+
+# Tab bar colors
 active_tab_background #272822
 active_tab_foreground #f8f8f2
 inactive_tab_background #383830
 inactive_tab_foreground #a59f85
 tab_bar_background #383830
-wayland_titlebar_color #272822
-macos_titlebar_color #272822
 
+# The 16 terminal colors
 # normal
 color0 #272822
 color1 #f92672

--- a/colors/base16-moonlight.conf
+++ b/colors/base16-moonlight.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Moonlight
+## author:   Jeremy Swinarton (https://github.com/jswinarton)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Moonlight
+
 # Scheme name: base16 Moonlight
 # Scheme author: Jeremy Swinarton (https://github.com/jswinarton)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #212337
 foreground #a3ace1
 selection_background #748cd6
 selection_foreground #a3ace1
-url_color #a1abe0
+
+# Cursor colors
 cursor #a3ace1
 cursor_text_color #212337
+
+# URL underline color when hovering with mouse
+url_color #a1abe0
+
+# Kitty window border colors
 active_border_color #748cd6
 inactive_border_color #403c64
+
+# OS Window titlebar colors
+wayland_titlebar_color #212337
+macos_titlebar_color #212337
+
+# Tab bar colors
 active_tab_background #212337
 active_tab_foreground #a3ace1
 inactive_tab_background #403c64
 inactive_tab_foreground #a1abe0
 tab_bar_background #403c64
-wayland_titlebar_color #212337
-macos_titlebar_color #212337
 
+# The 16 terminal colors
 # normal
 color0 #212337
 color1 #ff5370

--- a/colors/base16-mountain.conf
+++ b/colors/base16-mountain.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Mountain
+## author:   gnsfujiwara (https://github.com/gnsfujiwara)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Mountain
+
 # Scheme name: base16 Mountain
 # Scheme author: gnsfujiwara (https://github.com/gnsfujiwara)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0f0f0f
 foreground #cacaca
 selection_background #4c4c4c
 selection_foreground #cacaca
-url_color #ac8a8c
+
+# Cursor colors
 cursor #cacaca
 cursor_text_color #0f0f0f
+
+# URL underline color when hovering with mouse
+url_color #ac8a8c
+
+# Kitty window border colors
 active_border_color #4c4c4c
 inactive_border_color #191919
+
+# OS Window titlebar colors
+wayland_titlebar_color #0f0f0f
+macos_titlebar_color #0f0f0f
+
+# Tab bar colors
 active_tab_background #0f0f0f
 active_tab_foreground #cacaca
 inactive_tab_background #191919
 inactive_tab_foreground #ac8a8c
 tab_bar_background #191919
-wayland_titlebar_color #0f0f0f
-macos_titlebar_color #0f0f0f
 
+# The 16 terminal colors
 # normal
 color0 #0f0f0f
 color1 #ac8a8c

--- a/colors/base16-nebula.conf
+++ b/colors/base16-nebula.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Nebula
+## author:   Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Nebula
+
 # Scheme name: base16 Nebula
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #22273b
 foreground #a4a6a9
 selection_background #6e6f72
 selection_foreground #a4a6a9
-url_color #87888b
+
+# Cursor colors
 cursor #a4a6a9
 cursor_text_color #22273b
+
+# URL underline color when hovering with mouse
+url_color #87888b
+
+# Kitty window border colors
 active_border_color #6e6f72
 inactive_border_color #414f60
+
+# OS Window titlebar colors
+wayland_titlebar_color #22273b
+macos_titlebar_color #22273b
+
+# Tab bar colors
 active_tab_background #22273b
 active_tab_foreground #a4a6a9
 inactive_tab_background #414f60
 inactive_tab_foreground #87888b
 tab_bar_background #414f60
-wayland_titlebar_color #22273b
-macos_titlebar_color #22273b
 
+# The 16 terminal colors
 # normal
 color0 #22273b
 color1 #777abc

--- a/colors/base16-nord-light.conf
+++ b/colors/base16-nord-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Nord Light
+## author:   threddast, based on fuxialexander&#39;s doom-nord-light-theme (Doom Emacs)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Nord Light
+
 # Scheme name: base16 Nord Light
 # Scheme author: threddast, based on fuxialexander&#39;s doom-nord-light-theme (Doom Emacs)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #e5e9f0
 foreground #2e3440
 selection_background #aebacf
 selection_foreground #2e3440
-url_color #60728c
+
+# Cursor colors
 cursor #2e3440
 cursor_text_color #e5e9f0
+
+# URL underline color when hovering with mouse
+url_color #60728c
+
+# Kitty window border colors
 active_border_color #aebacf
 inactive_border_color #c2d0e7
+
+# OS Window titlebar colors
+wayland_titlebar_color #e5e9f0
+macos_titlebar_color #e5e9f0
+
+# Tab bar colors
 active_tab_background #e5e9f0
 active_tab_foreground #2e3440
 inactive_tab_background #c2d0e7
 inactive_tab_foreground #60728c
 tab_bar_background #c2d0e7
-wayland_titlebar_color #e5e9f0
-macos_titlebar_color #e5e9f0
 
+# The 16 terminal colors
 # normal
 color0 #e5e9f0
 color1 #99324b

--- a/colors/base16-nord.conf
+++ b/colors/base16-nord.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Nord
+## author:   arcticicestudio
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Nord
+
 # Scheme name: base16 Nord
 # Scheme author: arcticicestudio
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2e3440
 foreground #e5e9f0
 selection_background #4c566a
 selection_foreground #e5e9f0
-url_color #d8dee9
+
+# Cursor colors
 cursor #e5e9f0
 cursor_text_color #2e3440
+
+# URL underline color when hovering with mouse
+url_color #d8dee9
+
+# Kitty window border colors
 active_border_color #4c566a
 inactive_border_color #3b4252
+
+# OS Window titlebar colors
+wayland_titlebar_color #2e3440
+macos_titlebar_color #2e3440
+
+# Tab bar colors
 active_tab_background #2e3440
 active_tab_foreground #e5e9f0
 inactive_tab_background #3b4252
 inactive_tab_foreground #d8dee9
 tab_bar_background #3b4252
-wayland_titlebar_color #2e3440
-macos_titlebar_color #2e3440
 
+# The 16 terminal colors
 # normal
 color0 #2e3440
 color1 #bf616a

--- a/colors/base16-nova.conf
+++ b/colors/base16-nova.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Nova
+## author:   George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Nova
+
 # Scheme name: base16 Nova
 # Scheme author: George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #3c4c55
 foreground #c5d4dd
 selection_background #899ba6
 selection_foreground #c5d4dd
-url_color #899ba6
+
+# Cursor colors
 cursor #c5d4dd
 cursor_text_color #3c4c55
+
+# URL underline color when hovering with mouse
+url_color #899ba6
+
+# Kitty window border colors
 active_border_color #899ba6
 inactive_border_color #556873
+
+# OS Window titlebar colors
+wayland_titlebar_color #3c4c55
+macos_titlebar_color #3c4c55
+
+# Tab bar colors
 active_tab_background #3c4c55
 active_tab_foreground #c5d4dd
 inactive_tab_background #556873
 inactive_tab_foreground #899ba6
 tab_bar_background #556873
-wayland_titlebar_color #3c4c55
-macos_titlebar_color #3c4c55
 
+# The 16 terminal colors
 # normal
 color0 #3c4c55
 color1 #83afe5

--- a/colors/base16-ocean.conf
+++ b/colors/base16-ocean.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Ocean
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Ocean
+
 # Scheme name: base16 Ocean
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2b303b
 foreground #c0c5ce
 selection_background #65737e
 selection_foreground #c0c5ce
-url_color #a7adba
+
+# Cursor colors
 cursor #c0c5ce
 cursor_text_color #2b303b
+
+# URL underline color when hovering with mouse
+url_color #a7adba
+
+# Kitty window border colors
 active_border_color #65737e
 inactive_border_color #343d46
+
+# OS Window titlebar colors
+wayland_titlebar_color #2b303b
+macos_titlebar_color #2b303b
+
+# Tab bar colors
 active_tab_background #2b303b
 active_tab_foreground #c0c5ce
 inactive_tab_background #343d46
 inactive_tab_foreground #a7adba
 tab_bar_background #343d46
-wayland_titlebar_color #2b303b
-macos_titlebar_color #2b303b
 
+# The 16 terminal colors
 # normal
 color0 #2b303b
 color1 #bf616a

--- a/colors/base16-oceanicnext.conf
+++ b/colors/base16-oceanicnext.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 OceanicNext
+## author:   https://github.com/voronianski/oceanic-next-color-scheme
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    OceanicNext
+
 # Scheme name: base16 OceanicNext
 # Scheme author: https://github.com/voronianski/oceanic-next-color-scheme
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1b2b34
 foreground #c0c5ce
 selection_background #65737e
 selection_foreground #c0c5ce
-url_color #a7adba
+
+# Cursor colors
 cursor #c0c5ce
 cursor_text_color #1b2b34
+
+# URL underline color when hovering with mouse
+url_color #a7adba
+
+# Kitty window border colors
 active_border_color #65737e
 inactive_border_color #343d46
+
+# OS Window titlebar colors
+wayland_titlebar_color #1b2b34
+macos_titlebar_color #1b2b34
+
+# Tab bar colors
 active_tab_background #1b2b34
 active_tab_foreground #c0c5ce
 inactive_tab_background #343d46
 inactive_tab_foreground #a7adba
 tab_bar_background #343d46
-wayland_titlebar_color #1b2b34
-macos_titlebar_color #1b2b34
 
+# The 16 terminal colors
 # normal
 color0 #1b2b34
 color1 #ec5f67

--- a/colors/base16-one-light.conf
+++ b/colors/base16-one-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 One Light
+## author:   Daniel Pfeifer (http://github.com/purpleKarrot)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    One Light
+
 # Scheme name: base16 One Light
 # Scheme author: Daniel Pfeifer (http://github.com/purpleKarrot)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fafafa
 foreground #383a42
 selection_background #a0a1a7
 selection_foreground #383a42
-url_color #696c77
+
+# Cursor colors
 cursor #383a42
 cursor_text_color #fafafa
+
+# URL underline color when hovering with mouse
+url_color #696c77
+
+# Kitty window border colors
 active_border_color #a0a1a7
 inactive_border_color #f0f0f1
+
+# OS Window titlebar colors
+wayland_titlebar_color #fafafa
+macos_titlebar_color #fafafa
+
+# Tab bar colors
 active_tab_background #fafafa
 active_tab_foreground #383a42
 inactive_tab_background #f0f0f1
 inactive_tab_foreground #696c77
 tab_bar_background #f0f0f1
-wayland_titlebar_color #fafafa
-macos_titlebar_color #fafafa
 
+# The 16 terminal colors
 # normal
 color0 #fafafa
 color1 #ca1243

--- a/colors/base16-onedark-dark.conf
+++ b/colors/base16-onedark-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 OneDark Dark
+## author:   olimorris (https://github.com/olimorris)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    OneDark Dark
+
 # Scheme name: base16 OneDark Dark
 # Scheme author: olimorris (https://github.com/olimorris)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #abb2bf
 selection_background #434852
 selection_foreground #abb2bf
-url_color #565c64
+
+# Cursor colors
 cursor #abb2bf
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #565c64
+
+# Kitty window border colors
 active_border_color #434852
 inactive_border_color #1c1f24
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #abb2bf
 inactive_tab_background #1c1f24
 inactive_tab_foreground #565c64
 tab_bar_background #1c1f24
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #ef596f

--- a/colors/base16-onedark.conf
+++ b/colors/base16-onedark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 OneDark
+## author:   Lalit Magant (http://github.com/tilal6991)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    OneDark
+
 # Scheme name: base16 OneDark
 # Scheme author: Lalit Magant (http://github.com/tilal6991)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282c34
 foreground #abb2bf
 selection_background #545862
 selection_foreground #abb2bf
-url_color #565c64
+
+# Cursor colors
 cursor #abb2bf
 cursor_text_color #282c34
+
+# URL underline color when hovering with mouse
+url_color #565c64
+
+# Kitty window border colors
 active_border_color #545862
 inactive_border_color #353b45
+
+# OS Window titlebar colors
+wayland_titlebar_color #282c34
+macos_titlebar_color #282c34
+
+# Tab bar colors
 active_tab_background #282c34
 active_tab_foreground #abb2bf
 inactive_tab_background #353b45
 inactive_tab_foreground #565c64
 tab_bar_background #353b45
-wayland_titlebar_color #282c34
-macos_titlebar_color #282c34
 
+# The 16 terminal colors
 # normal
 color0 #282c34
 color1 #e06c75

--- a/colors/base16-outrun-dark.conf
+++ b/colors/base16-outrun-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Outrun Dark
+## author:   Hugo Delahousse (http://github.com/hugodelahousse/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Outrun Dark
+
 # Scheme name: base16 Outrun Dark
 # Scheme author: Hugo Delahousse (http://github.com/hugodelahousse/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #00002a
 foreground #d0d0fa
 selection_background #50507a
 selection_foreground #d0d0fa
-url_color #b0b0da
+
+# Cursor colors
 cursor #d0d0fa
 cursor_text_color #00002a
+
+# URL underline color when hovering with mouse
+url_color #b0b0da
+
+# Kitty window border colors
 active_border_color #50507a
 inactive_border_color #20204a
+
+# OS Window titlebar colors
+wayland_titlebar_color #00002a
+macos_titlebar_color #00002a
+
+# Tab bar colors
 active_tab_background #00002a
 active_tab_foreground #d0d0fa
 inactive_tab_background #20204a
 inactive_tab_foreground #b0b0da
 tab_bar_background #20204a
-wayland_titlebar_color #00002a
-macos_titlebar_color #00002a
 
+# The 16 terminal colors
 # normal
 color0 #00002a
 color1 #ff4242

--- a/colors/base16-oxocarbon-dark.conf
+++ b/colors/base16-oxocarbon-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Oxocarbon Dark
+## author:   shaunsingh/IBM
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Oxocarbon Dark
+
 # Scheme name: base16 Oxocarbon Dark
 # Scheme author: shaunsingh/IBM
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #161616
 foreground #f2f4f8
 selection_background #525252
 selection_foreground #f2f4f8
-url_color #dde1e6
+
+# Cursor colors
 cursor #f2f4f8
 cursor_text_color #161616
+
+# URL underline color when hovering with mouse
+url_color #dde1e6
+
+# Kitty window border colors
 active_border_color #525252
 inactive_border_color #262626
+
+# OS Window titlebar colors
+wayland_titlebar_color #161616
+macos_titlebar_color #161616
+
+# Tab bar colors
 active_tab_background #161616
 active_tab_foreground #f2f4f8
 inactive_tab_background #262626
 inactive_tab_foreground #dde1e6
 tab_bar_background #262626
-wayland_titlebar_color #161616
-macos_titlebar_color #161616
 
+# The 16 terminal colors
 # normal
 color0 #161616
 color1 #3ddbd9

--- a/colors/base16-oxocarbon-light.conf
+++ b/colors/base16-oxocarbon-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Oxocarbon Light
+## author:   shaunsingh/IBM
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Oxocarbon Light
+
 # Scheme name: base16 Oxocarbon Light
 # Scheme author: shaunsingh/IBM
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f2f4f8
 foreground #393939
 selection_background #161616
 selection_foreground #393939
-url_color #262626
+
+# Cursor colors
 cursor #393939
 cursor_text_color #f2f4f8
+
+# URL underline color when hovering with mouse
+url_color #262626
+
+# Kitty window border colors
 active_border_color #161616
 inactive_border_color #dde1e6
+
+# OS Window titlebar colors
+wayland_titlebar_color #f2f4f8
+macos_titlebar_color #f2f4f8
+
+# Tab bar colors
 active_tab_background #f2f4f8
 active_tab_foreground #393939
 inactive_tab_background #dde1e6
 inactive_tab_foreground #262626
 tab_bar_background #dde1e6
-wayland_titlebar_color #f2f4f8
-macos_titlebar_color #f2f4f8
 
+# The 16 terminal colors
 # normal
 color0 #f2f4f8
 color1 #ff7eb6

--- a/colors/base16-pandora.conf
+++ b/colors/base16-pandora.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 pandora
+## author:   Cassandra Fox
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    pandora
+
 # Scheme name: base16 pandora
 # Scheme author: Cassandra Fox
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #131213
 foreground #f15c99
 selection_background #ffbee3
 selection_foreground #f15c99
-url_color #9b2a46
+
+# Cursor colors
 cursor #f15c99
 cursor_text_color #131213
+
+# URL underline color when hovering with mouse
+url_color #9b2a46
+
+# Kitty window border colors
 active_border_color #ffbee3
 inactive_border_color #2f1823
+
+# OS Window titlebar colors
+wayland_titlebar_color #131213
+macos_titlebar_color #131213
+
+# Tab bar colors
 active_tab_background #131213
 active_tab_foreground #f15c99
 inactive_tab_background #2f1823
 inactive_tab_foreground #9b2a46
 tab_bar_background #2f1823
-wayland_titlebar_color #131213
-macos_titlebar_color #131213
 
+# The 16 terminal colors
 # normal
 color0 #131213
 color1 #b00b69

--- a/colors/base16-papercolor-dark.conf
+++ b/colors/base16-papercolor-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 PaperColor Dark
+## author:   Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    PaperColor Dark
+
 # Scheme name: base16 PaperColor Dark
 # Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1c1c
 foreground #808080
 selection_background #d7af5f
 selection_foreground #808080
-url_color #5fafd7
+
+# Cursor colors
 cursor #808080
 cursor_text_color #1c1c1c
+
+# URL underline color when hovering with mouse
+url_color #5fafd7
+
+# Kitty window border colors
 active_border_color #d7af5f
 inactive_border_color #af005f
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1c1c
+macos_titlebar_color #1c1c1c
+
+# Tab bar colors
 active_tab_background #1c1c1c
 active_tab_foreground #808080
 inactive_tab_background #af005f
 inactive_tab_foreground #5fafd7
 tab_bar_background #af005f
-wayland_titlebar_color #1c1c1c
-macos_titlebar_color #1c1c1c
 
+# The 16 terminal colors
 # normal
 color0 #1c1c1c
 color1 #585858

--- a/colors/base16-papercolor-light.conf
+++ b/colors/base16-papercolor-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 PaperColor Light
+## author:   Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    PaperColor Light
+
 # Scheme name: base16 PaperColor Light
 # Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #eeeeee
 foreground #444444
 selection_background #5f8700
 selection_foreground #444444
-url_color #0087af
+
+# Cursor colors
 cursor #444444
 cursor_text_color #eeeeee
+
+# URL underline color when hovering with mouse
+url_color #0087af
+
+# Kitty window border colors
 active_border_color #5f8700
 inactive_border_color #af0000
+
+# OS Window titlebar colors
+wayland_titlebar_color #eeeeee
+macos_titlebar_color #eeeeee
+
+# Tab bar colors
 active_tab_background #eeeeee
 active_tab_foreground #444444
 inactive_tab_background #af0000
 inactive_tab_foreground #0087af
 tab_bar_background #af0000
-wayland_titlebar_color #eeeeee
-macos_titlebar_color #eeeeee
 
+# The 16 terminal colors
 # normal
 color0 #eeeeee
 color1 #bcbcbc

--- a/colors/base16-paraiso.conf
+++ b/colors/base16-paraiso.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Paraiso
+## author:   Jan T. Sott
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Paraiso
+
 # Scheme name: base16 Paraiso
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2f1e2e
 foreground #a39e9b
 selection_background #776e71
 selection_foreground #a39e9b
-url_color #8d8687
+
+# Cursor colors
 cursor #a39e9b
 cursor_text_color #2f1e2e
+
+# URL underline color when hovering with mouse
+url_color #8d8687
+
+# Kitty window border colors
 active_border_color #776e71
 inactive_border_color #41323f
+
+# OS Window titlebar colors
+wayland_titlebar_color #2f1e2e
+macos_titlebar_color #2f1e2e
+
+# Tab bar colors
 active_tab_background #2f1e2e
 active_tab_foreground #a39e9b
 inactive_tab_background #41323f
 inactive_tab_foreground #8d8687
 tab_bar_background #41323f
-wayland_titlebar_color #2f1e2e
-macos_titlebar_color #2f1e2e
 
+# The 16 terminal colors
 # normal
 color0 #2f1e2e
 color1 #ef6155

--- a/colors/base16-pasque.conf
+++ b/colors/base16-pasque.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Pasque
+## author:   Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Pasque
+
 # Scheme name: base16 Pasque
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #271c3a
 foreground #dedcdf
 selection_background #5d5766
 selection_foreground #dedcdf
-url_color #bebcbf
+
+# Cursor colors
 cursor #dedcdf
 cursor_text_color #271c3a
+
+# URL underline color when hovering with mouse
+url_color #bebcbf
+
+# Kitty window border colors
 active_border_color #5d5766
 inactive_border_color #100323
+
+# OS Window titlebar colors
+wayland_titlebar_color #271c3a
+macos_titlebar_color #271c3a
+
+# Tab bar colors
 active_tab_background #271c3a
 active_tab_foreground #dedcdf
 inactive_tab_background #100323
 inactive_tab_foreground #bebcbf
 tab_bar_background #100323
-wayland_titlebar_color #271c3a
-macos_titlebar_color #271c3a
 
+# The 16 terminal colors
 # normal
 color0 #271c3a
 color1 #a92258

--- a/colors/base16-phd.conf
+++ b/colors/base16-phd.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 PhD
+## author:   Hennig Hasemann (http://leetless.de/vim.html)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    PhD
+
 # Scheme name: base16 PhD
 # Scheme author: Hennig Hasemann (http://leetless.de/vim.html)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #061229
 foreground #b8bbc2
 selection_background #717885
 selection_foreground #b8bbc2
-url_color #9a99a3
+
+# Cursor colors
 cursor #b8bbc2
 cursor_text_color #061229
+
+# URL underline color when hovering with mouse
+url_color #9a99a3
+
+# Kitty window border colors
 active_border_color #717885
 inactive_border_color #2a3448
+
+# OS Window titlebar colors
+wayland_titlebar_color #061229
+macos_titlebar_color #061229
+
+# Tab bar colors
 active_tab_background #061229
 active_tab_foreground #b8bbc2
 inactive_tab_background #2a3448
 inactive_tab_foreground #9a99a3
 tab_bar_background #2a3448
-wayland_titlebar_color #061229
-macos_titlebar_color #061229
 
+# The 16 terminal colors
 # normal
 color0 #061229
 color1 #d07346

--- a/colors/base16-pico.conf
+++ b/colors/base16-pico.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Pico
+## author:   PICO-8 (http://www.lexaloffle.com/pico-8.php)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Pico
+
 # Scheme name: base16 Pico
 # Scheme author: PICO-8 (http://www.lexaloffle.com/pico-8.php)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #5f574f
 selection_background #008751
 selection_foreground #5f574f
-url_color #ab5236
+
+# Cursor colors
 cursor #5f574f
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #ab5236
+
+# Kitty window border colors
 active_border_color #008751
 inactive_border_color #1d2b53
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #5f574f
 inactive_tab_background #1d2b53
 inactive_tab_foreground #ab5236
 tab_bar_background #1d2b53
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #ff004d

--- a/colors/base16-pinky.conf
+++ b/colors/base16-pinky.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 pinky
+## author:   Benjamin (https://github.com/b3nj5m1n)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    pinky
+
 # Scheme name: base16 pinky
 # Scheme author: Benjamin (https://github.com/b3nj5m1n)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171517
 foreground #f5f5f5
 selection_background #383338
 selection_foreground #f5f5f5
-url_color #e7dbdb
+
+# Cursor colors
 cursor #f5f5f5
 cursor_text_color #171517
+
+# URL underline color when hovering with mouse
+url_color #e7dbdb
+
+# Kitty window border colors
 active_border_color #383338
 inactive_border_color #1b181b
+
+# OS Window titlebar colors
+wayland_titlebar_color #171517
+macos_titlebar_color #171517
+
+# Tab bar colors
 active_tab_background #171517
 active_tab_foreground #f5f5f5
 inactive_tab_background #1b181b
 inactive_tab_foreground #e7dbdb
 tab_bar_background #1b181b
-wayland_titlebar_color #171517
-macos_titlebar_color #171517
 
+# The 16 terminal colors
 # normal
 color0 #171517
 color1 #ffa600

--- a/colors/base16-pop.conf
+++ b/colors/base16-pop.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Pop
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Pop
+
 # Scheme name: base16 Pop
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #d0d0d0
 selection_background #505050
 selection_foreground #d0d0d0
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #eb008a

--- a/colors/base16-porple.conf
+++ b/colors/base16-porple.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Porple
+## author:   Niek den Breeje (https://github.com/AuditeMarlow)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Porple
+
 # Scheme name: base16 Porple
 # Scheme author: Niek den Breeje (https://github.com/AuditeMarlow)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292c36
 foreground #d8d8d8
 selection_background #65568a
 selection_foreground #d8d8d8
-url_color #b8b8b8
+
+# Cursor colors
 cursor #d8d8d8
 cursor_text_color #292c36
+
+# URL underline color when hovering with mouse
+url_color #b8b8b8
+
+# Kitty window border colors
 active_border_color #65568a
 inactive_border_color #333344
+
+# OS Window titlebar colors
+wayland_titlebar_color #292c36
+macos_titlebar_color #292c36
+
+# Tab bar colors
 active_tab_background #292c36
 active_tab_foreground #d8d8d8
 inactive_tab_background #333344
 inactive_tab_foreground #b8b8b8
 tab_bar_background #333344
-wayland_titlebar_color #292c36
-macos_titlebar_color #292c36
 
+# The 16 terminal colors
 # normal
 color0 #292c36
 color1 #f84547

--- a/colors/base16-precious-dark-eleven.conf
+++ b/colors/base16-precious-dark-eleven.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Precious Dark Eleven
+## author:   4lex4 &lt;4lex49@zoho.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Precious Dark Eleven
+
 # Scheme name: base16 Precious Dark Eleven
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1e20
 foreground #b8b7b6
 selection_background #858585
 selection_foreground #b8b7b6
-url_color #a8a8a7
+
+# Cursor colors
 cursor #b8b7b6
 cursor_text_color #1c1e20
+
+# URL underline color when hovering with mouse
+url_color #a8a8a7
+
+# Kitty window border colors
 active_border_color #858585
 inactive_border_color #292b2d
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1e20
+macos_titlebar_color #1c1e20
+
+# Tab bar colors
 active_tab_background #1c1e20
 active_tab_foreground #b8b7b6
 inactive_tab_background #292b2d
 inactive_tab_foreground #a8a8a7
 tab_bar_background #292b2d
-wayland_titlebar_color #1c1e20
-macos_titlebar_color #1c1e20
 
+# The 16 terminal colors
 # normal
 color0 #1c1e20
 color1 #ff8782

--- a/colors/base16-precious-dark-fifteen.conf
+++ b/colors/base16-precious-dark-fifteen.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Precious Dark Fifteen
+## author:   4lex4 &lt;4lex49@zoho.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Precious Dark Fifteen
+
 # Scheme name: base16 Precious Dark Fifteen
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #23262b
 foreground #bab9b6
 selection_background #898989
 selection_foreground #bab9b6
-url_color #abaaa8
+
+# Cursor colors
 cursor #bab9b6
 cursor_text_color #23262b
+
+# URL underline color when hovering with mouse
+url_color #abaaa8
+
+# Kitty window border colors
 active_border_color #898989
 inactive_border_color #303337
+
+# OS Window titlebar colors
+wayland_titlebar_color #23262b
+macos_titlebar_color #23262b
+
+# Tab bar colors
 active_tab_background #23262b
 active_tab_foreground #bab9b6
 inactive_tab_background #303337
 inactive_tab_foreground #abaaa8
 tab_bar_background #303337
-wayland_titlebar_color #23262b
-macos_titlebar_color #23262b
 
+# The 16 terminal colors
 # normal
 color0 #23262b
 color1 #ff8782

--- a/colors/base16-precious-light-warm.conf
+++ b/colors/base16-precious-light-warm.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Precious Light Warm
+## author:   4lex4 &lt;4lex49@zoho.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Precious Light Warm
+
 # Scheme name: base16 Precious Light Warm
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fff5e5
 foreground #4e5359
 selection_background #7f8080
 selection_foreground #4e5359
-url_color #5d6065
+
+# Cursor colors
 cursor #4e5359
 cursor_text_color #fff5e5
+
+# URL underline color when hovering with mouse
+url_color #5d6065
+
+# Kitty window border colors
 active_border_color #7f8080
 inactive_border_color #ece4d6
+
+# OS Window titlebar colors
+wayland_titlebar_color #fff5e5
+macos_titlebar_color #fff5e5
+
+# Tab bar colors
 active_tab_background #fff5e5
 active_tab_foreground #4e5359
 inactive_tab_background #ece4d6
 inactive_tab_foreground #5d6065
 tab_bar_background #ece4d6
-wayland_titlebar_color #fff5e5
-macos_titlebar_color #fff5e5
 
+# The 16 terminal colors
 # normal
 color0 #fff5e5
 color1 #b14745

--- a/colors/base16-precious-light-white.conf
+++ b/colors/base16-precious-light-white.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Precious Light White
+## author:   4lex4 &lt;4lex49@zoho.com&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Precious Light White
+
 # Scheme name: base16 Precious Light White
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #555555
 selection_background #848484
 selection_foreground #555555
-url_color #636363
+
+# Cursor colors
 cursor #555555
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #636363
+
+# Kitty window border colors
 active_border_color #848484
 inactive_border_color #ededed
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #555555
 inactive_tab_background #ededed
 inactive_tab_foreground #636363
 tab_bar_background #ededed
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #af4947

--- a/colors/base16-primer-dark-dimmed.conf
+++ b/colors/base16-primer-dark-dimmed.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Primer Dark Dimmed
+## author:   Jimmy Lin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Primer Dark Dimmed
+
 # Scheme name: base16 Primer Dark Dimmed
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c2128
 foreground #909dab
 selection_background #545d68
 selection_foreground #909dab
-url_color #768390
+
+# Cursor colors
 cursor #909dab
 cursor_text_color #1c2128
+
+# URL underline color when hovering with mouse
+url_color #768390
+
+# Kitty window border colors
 active_border_color #545d68
 inactive_border_color #373e47
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c2128
+macos_titlebar_color #1c2128
+
+# Tab bar colors
 active_tab_background #1c2128
 active_tab_foreground #909dab
 inactive_tab_background #373e47
 inactive_tab_foreground #768390
 tab_bar_background #373e47
-wayland_titlebar_color #1c2128
-macos_titlebar_color #1c2128
 
+# The 16 terminal colors
 # normal
 color0 #1c2128
 color1 #f47067

--- a/colors/base16-primer-dark.conf
+++ b/colors/base16-primer-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Primer Dark
+## author:   Jimmy Lin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Primer Dark
+
 # Scheme name: base16 Primer Dark
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #010409
 foreground #b1bac4
 selection_background #484f58
 selection_foreground #b1bac4
-url_color #8b949e
+
+# Cursor colors
 cursor #b1bac4
 cursor_text_color #010409
+
+# URL underline color when hovering with mouse
+url_color #8b949e
+
+# Kitty window border colors
 active_border_color #484f58
 inactive_border_color #21262d
+
+# OS Window titlebar colors
+wayland_titlebar_color #010409
+macos_titlebar_color #010409
+
+# Tab bar colors
 active_tab_background #010409
 active_tab_foreground #b1bac4
 inactive_tab_background #21262d
 inactive_tab_foreground #8b949e
 tab_bar_background #21262d
-wayland_titlebar_color #010409
-macos_titlebar_color #010409
 
+# The 16 terminal colors
 # normal
 color0 #010409
 color1 #ff7b72

--- a/colors/base16-primer-light.conf
+++ b/colors/base16-primer-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Primer Light
+## author:   Jimmy Lin
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Primer Light
+
 # Scheme name: base16 Primer Light
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fafbfc
 foreground #2f363d
 selection_background #959da5
 selection_foreground #2f363d
-url_color #444d56
+
+# Cursor colors
 cursor #2f363d
 cursor_text_color #fafbfc
+
+# URL underline color when hovering with mouse
+url_color #444d56
+
+# Kitty window border colors
 active_border_color #959da5
 inactive_border_color #e1e4e8
+
+# OS Window titlebar colors
+wayland_titlebar_color #fafbfc
+macos_titlebar_color #fafbfc
+
+# Tab bar colors
 active_tab_background #fafbfc
 active_tab_foreground #2f363d
 inactive_tab_background #e1e4e8
 inactive_tab_foreground #444d56
 tab_bar_background #e1e4e8
-wayland_titlebar_color #fafbfc
-macos_titlebar_color #fafbfc
 
+# The 16 terminal colors
 # normal
 color0 #fafbfc
 color1 #d73a49

--- a/colors/base16-purpledream.conf
+++ b/colors/base16-purpledream.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Purpledream
+## author:   malet
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Purpledream
+
 # Scheme name: base16 Purpledream
 # Scheme author: malet
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #100510
 foreground #ddd0dd
 selection_background #605060
 selection_foreground #ddd0dd
-url_color #bbb0bb
+
+# Cursor colors
 cursor #ddd0dd
 cursor_text_color #100510
+
+# URL underline color when hovering with mouse
+url_color #bbb0bb
+
+# Kitty window border colors
 active_border_color #605060
 inactive_border_color #302030
+
+# OS Window titlebar colors
+wayland_titlebar_color #100510
+macos_titlebar_color #100510
+
+# Tab bar colors
 active_tab_background #100510
 active_tab_foreground #ddd0dd
 inactive_tab_background #302030
 inactive_tab_foreground #bbb0bb
 tab_bar_background #302030
-wayland_titlebar_color #100510
-macos_titlebar_color #100510
 
+# The 16 terminal colors
 # normal
 color0 #100510
 color1 #ff1d0d

--- a/colors/base16-qualia.conf
+++ b/colors/base16-qualia.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Qualia
+## author:   isaacwhanson
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Qualia
+
 # Scheme name: base16 Qualia
 # Scheme author: isaacwhanson
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #101010
 foreground #c0c0c0
 selection_background #454545
 selection_foreground #c0c0c0
-url_color #808080
+
+# Cursor colors
 cursor #c0c0c0
 cursor_text_color #101010
+
+# URL underline color when hovering with mouse
+url_color #808080
+
+# Kitty window border colors
 active_border_color #454545
 inactive_border_color #454545
+
+# OS Window titlebar colors
+wayland_titlebar_color #101010
+macos_titlebar_color #101010
+
+# Tab bar colors
 active_tab_background #101010
 active_tab_foreground #c0c0c0
 inactive_tab_background #454545
 inactive_tab_foreground #808080
 tab_bar_background #454545
-wayland_titlebar_color #101010
-macos_titlebar_color #101010
 
+# The 16 terminal colors
 # normal
 color0 #101010
 color1 #efa6a2

--- a/colors/base16-railscasts.conf
+++ b/colors/base16-railscasts.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Railscasts
+## author:   Ryan Bates (http://railscasts.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Railscasts
+
 # Scheme name: base16 Railscasts
 # Scheme author: Ryan Bates (http://railscasts.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2b2b2b
 foreground #e6e1dc
 selection_background #5a647e
 selection_foreground #e6e1dc
-url_color #d4cfc9
+
+# Cursor colors
 cursor #e6e1dc
 cursor_text_color #2b2b2b
+
+# URL underline color when hovering with mouse
+url_color #d4cfc9
+
+# Kitty window border colors
 active_border_color #5a647e
 inactive_border_color #272935
+
+# OS Window titlebar colors
+wayland_titlebar_color #2b2b2b
+macos_titlebar_color #2b2b2b
+
+# Tab bar colors
 active_tab_background #2b2b2b
 active_tab_foreground #e6e1dc
 inactive_tab_background #272935
 inactive_tab_foreground #d4cfc9
 tab_bar_background #272935
-wayland_titlebar_color #2b2b2b
-macos_titlebar_color #2b2b2b
 
+# The 16 terminal colors
 # normal
 color0 #2b2b2b
 color1 #da4939

--- a/colors/base16-rebecca.conf
+++ b/colors/base16-rebecca.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Rebecca
+## author:   Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Rebecca
+
 # Scheme name: base16 Rebecca
 # Scheme author: Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #292a44
 foreground #f1eff8
 selection_background #666699
 selection_foreground #f1eff8
-url_color #a0a0c5
+
+# Cursor colors
 cursor #f1eff8
 cursor_text_color #292a44
+
+# URL underline color when hovering with mouse
+url_color #a0a0c5
+
+# Kitty window border colors
 active_border_color #666699
 inactive_border_color #663399
+
+# OS Window titlebar colors
+wayland_titlebar_color #292a44
+macos_titlebar_color #292a44
+
+# Tab bar colors
 active_tab_background #292a44
 active_tab_foreground #f1eff8
 inactive_tab_background #663399
 inactive_tab_foreground #a0a0c5
 tab_bar_background #663399
-wayland_titlebar_color #292a44
-macos_titlebar_color #292a44
 
+# The 16 terminal colors
 # normal
 color0 #292a44
 color1 #a0a0c5

--- a/colors/base16-rose-pine-dawn.conf
+++ b/colors/base16-rose-pine-dawn.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Rosé Pine Dawn
+## author:   Emilia Dunfelt &lt;edun@dunfelt.se&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Rosé Pine Dawn
+
 # Scheme name: base16 Rosé Pine Dawn
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #faf4ed
 foreground #575279
 selection_background #9893a5
 selection_foreground #575279
-url_color #797593
+
+# Cursor colors
 cursor #575279
 cursor_text_color #faf4ed
+
+# URL underline color when hovering with mouse
+url_color #797593
+
+# Kitty window border colors
 active_border_color #9893a5
 inactive_border_color #fffaf3
+
+# OS Window titlebar colors
+wayland_titlebar_color #faf4ed
+macos_titlebar_color #faf4ed
+
+# Tab bar colors
 active_tab_background #faf4ed
 active_tab_foreground #575279
 inactive_tab_background #fffaf3
 inactive_tab_foreground #797593
 tab_bar_background #fffaf3
-wayland_titlebar_color #faf4ed
-macos_titlebar_color #faf4ed
 
+# The 16 terminal colors
 # normal
 color0 #faf4ed
 color1 #b4637a

--- a/colors/base16-rose-pine-moon.conf
+++ b/colors/base16-rose-pine-moon.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Rosé Pine Moon
+## author:   Emilia Dunfelt &lt;edun@dunfelt.se&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Rosé Pine Moon
+
 # Scheme name: base16 Rosé Pine Moon
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #232136
 foreground #e0def4
 selection_background #6e6a86
 selection_foreground #e0def4
-url_color #908caa
+
+# Cursor colors
 cursor #e0def4
 cursor_text_color #232136
+
+# URL underline color when hovering with mouse
+url_color #908caa
+
+# Kitty window border colors
 active_border_color #6e6a86
 inactive_border_color #2a273f
+
+# OS Window titlebar colors
+wayland_titlebar_color #232136
+macos_titlebar_color #232136
+
+# Tab bar colors
 active_tab_background #232136
 active_tab_foreground #e0def4
 inactive_tab_background #2a273f
 inactive_tab_foreground #908caa
 tab_bar_background #2a273f
-wayland_titlebar_color #232136
-macos_titlebar_color #232136
 
+# The 16 terminal colors
 # normal
 color0 #232136
 color1 #eb6f92

--- a/colors/base16-rose-pine.conf
+++ b/colors/base16-rose-pine.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Rosé Pine
+## author:   Emilia Dunfelt &lt;edun@dunfelt.se&gt;
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Rosé Pine
+
 # Scheme name: base16 Rosé Pine
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #191724
 foreground #e0def4
 selection_background #6e6a86
 selection_foreground #e0def4
-url_color #908caa
+
+# Cursor colors
 cursor #e0def4
 cursor_text_color #191724
+
+# URL underline color when hovering with mouse
+url_color #908caa
+
+# Kitty window border colors
 active_border_color #6e6a86
 inactive_border_color #1f1d2e
+
+# OS Window titlebar colors
+wayland_titlebar_color #191724
+macos_titlebar_color #191724
+
+# Tab bar colors
 active_tab_background #191724
 active_tab_foreground #e0def4
 inactive_tab_background #1f1d2e
 inactive_tab_foreground #908caa
 tab_bar_background #1f1d2e
-wayland_titlebar_color #191724
-macos_titlebar_color #191724
 
+# The 16 terminal colors
 # normal
 color0 #191724
 color1 #eb6f92

--- a/colors/base16-saga.conf
+++ b/colors/base16-saga.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 SAGA
+## author:   https://github.com/SAGAtheme/SAGA
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    SAGA
+
 # Scheme name: base16 SAGA
 # Scheme author: https://github.com/SAGAtheme/SAGA
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #05080a
 foreground #dce2f7
 selection_background #141f27
 selection_foreground #dce2f7
-url_color #192630
+
+# Cursor colors
 cursor #dce2f7
 cursor_text_color #05080a
+
+# URL underline color when hovering with mouse
+url_color #192630
+
+# Kitty window border colors
 active_border_color #141f27
 inactive_border_color #0a1014
+
+# OS Window titlebar colors
+wayland_titlebar_color #05080a
+macos_titlebar_color #05080a
+
+# Tab bar colors
 active_tab_background #05080a
 active_tab_foreground #dce2f7
 inactive_tab_background #0a1014
 inactive_tab_foreground #192630
 tab_bar_background #0a1014
-wayland_titlebar_color #05080a
-macos_titlebar_color #05080a
 
+# The 16 terminal colors
 # normal
 color0 #05080a
 color1 #ffd4e9

--- a/colors/base16-sagelight.conf
+++ b/colors/base16-sagelight.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Sagelight
+## author:   Carter Veldhuizen
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Sagelight
+
 # Scheme name: base16 Sagelight
 # Scheme author: Carter Veldhuizen
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f8f8f8
 foreground #383838
 selection_background #b8b8b8
 selection_foreground #383838
-url_color #585858
+
+# Cursor colors
 cursor #383838
 cursor_text_color #f8f8f8
+
+# URL underline color when hovering with mouse
+url_color #585858
+
+# Kitty window border colors
 active_border_color #b8b8b8
 inactive_border_color #e8e8e8
+
+# OS Window titlebar colors
+wayland_titlebar_color #f8f8f8
+macos_titlebar_color #f8f8f8
+
+# Tab bar colors
 active_tab_background #f8f8f8
 active_tab_foreground #383838
 inactive_tab_background #e8e8e8
 inactive_tab_foreground #585858
 tab_bar_background #e8e8e8
-wayland_titlebar_color #f8f8f8
-macos_titlebar_color #f8f8f8
 
+# The 16 terminal colors
 # normal
 color0 #f8f8f8
 color1 #fa8480

--- a/colors/base16-sakura.conf
+++ b/colors/base16-sakura.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Sakura
+## author:   Misterio77 (http://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Sakura
+
 # Scheme name: base16 Sakura
 # Scheme author: Misterio77 (http://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #feedf3
 foreground #564448
 selection_background #755f64
 selection_foreground #564448
-url_color #665055
+
+# Cursor colors
 cursor #564448
 cursor_text_color #feedf3
+
+# URL underline color when hovering with mouse
+url_color #665055
+
+# Kitty window border colors
 active_border_color #755f64
 inactive_border_color #f8e2e7
+
+# OS Window titlebar colors
+wayland_titlebar_color #feedf3
+macos_titlebar_color #feedf3
+
+# Tab bar colors
 active_tab_background #feedf3
 active_tab_foreground #564448
 inactive_tab_background #f8e2e7
 inactive_tab_foreground #665055
 tab_bar_background #f8e2e7
-wayland_titlebar_color #feedf3
-macos_titlebar_color #feedf3
 
+# The 16 terminal colors
 # normal
 color0 #feedf3
 color1 #df2d52

--- a/colors/base16-sandcastle.conf
+++ b/colors/base16-sandcastle.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Sandcastle
+## author:   George Essig (https://github.com/gessig)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Sandcastle
+
 # Scheme name: base16 Sandcastle
 # Scheme author: George Essig (https://github.com/gessig)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282c34
 foreground #a89984
 selection_background #665c54
 selection_foreground #a89984
-url_color #928374
+
+# Cursor colors
 cursor #a89984
 cursor_text_color #282c34
+
+# URL underline color when hovering with mouse
+url_color #928374
+
+# Kitty window border colors
 active_border_color #665c54
 inactive_border_color #2c323b
+
+# OS Window titlebar colors
+wayland_titlebar_color #282c34
+macos_titlebar_color #282c34
+
+# Tab bar colors
 active_tab_background #282c34
 active_tab_foreground #a89984
 inactive_tab_background #2c323b
 inactive_tab_foreground #928374
 tab_bar_background #2c323b
-wayland_titlebar_color #282c34
-macos_titlebar_color #282c34
 
+# The 16 terminal colors
 # normal
 color0 #282c34
 color1 #83a598

--- a/colors/base16-selenized-black.conf
+++ b/colors/base16-selenized-black.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 selenized-black
+## author:   Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    selenized-black
+
 # Scheme name: base16 selenized-black
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #181818
 foreground #b9b9b9
 selection_background #777777
 selection_foreground #b9b9b9
-url_color #777777
+
+# Cursor colors
 cursor #b9b9b9
 cursor_text_color #181818
+
+# URL underline color when hovering with mouse
+url_color #777777
+
+# Kitty window border colors
 active_border_color #777777
 inactive_border_color #252525
+
+# OS Window titlebar colors
+wayland_titlebar_color #181818
+macos_titlebar_color #181818
+
+# Tab bar colors
 active_tab_background #181818
 active_tab_foreground #b9b9b9
 inactive_tab_background #252525
 inactive_tab_foreground #777777
 tab_bar_background #252525
-wayland_titlebar_color #181818
-macos_titlebar_color #181818
 
+# The 16 terminal colors
 # normal
 color0 #181818
 color1 #ed4a46

--- a/colors/base16-selenized-dark.conf
+++ b/colors/base16-selenized-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 selenized-dark
+## author:   Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    selenized-dark
+
 # Scheme name: base16 selenized-dark
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #103c48
 foreground #adbcbc
 selection_background #72898f
 selection_foreground #adbcbc
-url_color #72898f
+
+# Cursor colors
 cursor #adbcbc
 cursor_text_color #103c48
+
+# URL underline color when hovering with mouse
+url_color #72898f
+
+# Kitty window border colors
 active_border_color #72898f
 inactive_border_color #184956
+
+# OS Window titlebar colors
+wayland_titlebar_color #103c48
+macos_titlebar_color #103c48
+
+# Tab bar colors
 active_tab_background #103c48
 active_tab_foreground #adbcbc
 inactive_tab_background #184956
 inactive_tab_foreground #72898f
 tab_bar_background #184956
-wayland_titlebar_color #103c48
-macos_titlebar_color #103c48
 
+# The 16 terminal colors
 # normal
 color0 #103c48
 color1 #fa5750

--- a/colors/base16-selenized-light.conf
+++ b/colors/base16-selenized-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 selenized-light
+## author:   Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    selenized-light
+
 # Scheme name: base16 selenized-light
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbf3db
 foreground #53676d
 selection_background #909995
 selection_foreground #53676d
-url_color #909995
+
+# Cursor colors
 cursor #53676d
 cursor_text_color #fbf3db
+
+# URL underline color when hovering with mouse
+url_color #909995
+
+# Kitty window border colors
 active_border_color #909995
 inactive_border_color #ece3cc
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbf3db
+macos_titlebar_color #fbf3db
+
+# Tab bar colors
 active_tab_background #fbf3db
 active_tab_foreground #53676d
 inactive_tab_background #ece3cc
 inactive_tab_foreground #909995
 tab_bar_background #ece3cc
-wayland_titlebar_color #fbf3db
-macos_titlebar_color #fbf3db
 
+# The 16 terminal colors
 # normal
 color0 #fbf3db
 color1 #cc1729

--- a/colors/base16-selenized-white.conf
+++ b/colors/base16-selenized-white.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 selenized-white
+## author:   Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    selenized-white
+
 # Scheme name: base16 selenized-white
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #474747
 selection_background #878787
 selection_foreground #474747
-url_color #878787
+
+# Cursor colors
 cursor #474747
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #878787
+
+# Kitty window border colors
 active_border_color #878787
 inactive_border_color #ebebeb
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #474747
 inactive_tab_background #ebebeb
 inactive_tab_foreground #878787
 tab_bar_background #ebebeb
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #bf0000

--- a/colors/base16-seti.conf
+++ b/colors/base16-seti.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Seti UI
+## author:   
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Seti UI
+
 # Scheme name: base16 Seti UI
 # Scheme author: 
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #151718
 foreground #d6d6d6
 selection_background #41535b
 selection_foreground #d6d6d6
-url_color #43a5d5
+
+# Cursor colors
 cursor #d6d6d6
 cursor_text_color #151718
+
+# URL underline color when hovering with mouse
+url_color #43a5d5
+
+# Kitty window border colors
 active_border_color #41535b
 inactive_border_color #282a2b
+
+# OS Window titlebar colors
+wayland_titlebar_color #151718
+macos_titlebar_color #151718
+
+# Tab bar colors
 active_tab_background #151718
 active_tab_foreground #d6d6d6
 inactive_tab_background #282a2b
 inactive_tab_foreground #43a5d5
 tab_bar_background #282a2b
-wayland_titlebar_color #151718
-macos_titlebar_color #151718
 
+# The 16 terminal colors
 # normal
 color0 #151718
 color1 #cd3f45

--- a/colors/base16-shades-of-purple.conf
+++ b/colors/base16-shades-of-purple.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Shades of Purple
+## author:   Iolar Demartini Junior (http://github.com/demartini), based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Shades of Purple
+
 # Scheme name: base16 Shades of Purple
 # Scheme author: Iolar Demartini Junior (http://github.com/demartini), based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1e1e3f
 foreground #c7c7c7
 selection_background #808080
 selection_foreground #c7c7c7
-url_color #6871ff
+
+# Cursor colors
 cursor #c7c7c7
 cursor_text_color #1e1e3f
+
+# URL underline color when hovering with mouse
+url_color #6871ff
+
+# Kitty window border colors
 active_border_color #808080
 inactive_border_color #43d426
+
+# OS Window titlebar colors
+wayland_titlebar_color #1e1e3f
+macos_titlebar_color #1e1e3f
+
+# Tab bar colors
 active_tab_background #1e1e3f
 active_tab_foreground #c7c7c7
 inactive_tab_background #43d426
 inactive_tab_foreground #6871ff
 tab_bar_background #43d426
-wayland_titlebar_color #1e1e3f
-macos_titlebar_color #1e1e3f
 
+# The 16 terminal colors
 # normal
 color0 #1e1e3f
 color1 #d90429

--- a/colors/base16-shadesmear-dark.conf
+++ b/colors/base16-shadesmear-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 ShadeSmear Dark
+## author:   Kyle Giammarco (http://kyle.giammar.co)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    ShadeSmear Dark
+
 # Scheme name: base16 ShadeSmear Dark
 # Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #232323
 foreground #dbdbdb
 selection_background #c0c0c0
 selection_foreground #dbdbdb
-url_color #e4e4e4
+
+# Cursor colors
 cursor #dbdbdb
 cursor_text_color #232323
+
+# URL underline color when hovering with mouse
+url_color #e4e4e4
+
+# Kitty window border colors
 active_border_color #c0c0c0
 inactive_border_color #1c1c1c
+
+# OS Window titlebar colors
+wayland_titlebar_color #232323
+macos_titlebar_color #232323
+
+# Tab bar colors
 active_tab_background #232323
 active_tab_foreground #dbdbdb
 inactive_tab_background #1c1c1c
 inactive_tab_foreground #e4e4e4
 tab_bar_background #1c1c1c
-wayland_titlebar_color #232323
-macos_titlebar_color #232323
 
+# The 16 terminal colors
 # normal
 color0 #232323
 color1 #cc5450

--- a/colors/base16-shadesmear-light.conf
+++ b/colors/base16-shadesmear-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 ShadeSmear Light
+## author:   Kyle Giammarco (http://kyle.giammar.co)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    ShadeSmear Light
+
 # Scheme name: base16 ShadeSmear Light
 # Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #dbdbdb
 foreground #232323
 selection_background #4e4e4e
 selection_foreground #232323
-url_color #1c1c1c
+
+# Cursor colors
 cursor #232323
 cursor_text_color #dbdbdb
+
+# URL underline color when hovering with mouse
+url_color #1c1c1c
+
+# Kitty window border colors
 active_border_color #4e4e4e
 inactive_border_color #e4e4e4
+
+# OS Window titlebar colors
+wayland_titlebar_color #dbdbdb
+macos_titlebar_color #dbdbdb
+
+# Tab bar colors
 active_tab_background #dbdbdb
 active_tab_foreground #232323
 inactive_tab_background #e4e4e4
 inactive_tab_foreground #1c1c1c
 tab_bar_background #e4e4e4
-wayland_titlebar_color #dbdbdb
-macos_titlebar_color #dbdbdb
 
+# The 16 terminal colors
 # normal
 color0 #dbdbdb
 color1 #cc5450

--- a/colors/base16-shapeshifter.conf
+++ b/colors/base16-shapeshifter.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Shapeshifter
+## author:   Tyler Benziger (http://tybenz.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Shapeshifter
+
 # Scheme name: base16 Shapeshifter
 # Scheme author: Tyler Benziger (http://tybenz.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f9f9f9
 foreground #102015
 selection_background #555555
 selection_foreground #102015
-url_color #343434
+
+# Cursor colors
 cursor #102015
 cursor_text_color #f9f9f9
+
+# URL underline color when hovering with mouse
+url_color #343434
+
+# Kitty window border colors
 active_border_color #555555
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #f9f9f9
+macos_titlebar_color #f9f9f9
+
+# Tab bar colors
 active_tab_background #f9f9f9
 active_tab_foreground #102015
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #343434
 tab_bar_background #e0e0e0
-wayland_titlebar_color #f9f9f9
-macos_titlebar_color #f9f9f9
 
+# The 16 terminal colors
 # normal
 color0 #f9f9f9
 color1 #e92f2f

--- a/colors/base16-silk-dark.conf
+++ b/colors/base16-silk-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Silk Dark
+## author:   Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Silk Dark
+
 # Scheme name: base16 Silk Dark
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0e3c46
 foreground #c7dbdd
 selection_background #587073
 selection_foreground #c7dbdd
-url_color #9dc8cd
+
+# Cursor colors
 cursor #c7dbdd
 cursor_text_color #0e3c46
+
+# URL underline color when hovering with mouse
+url_color #9dc8cd
+
+# Kitty window border colors
 active_border_color #587073
 inactive_border_color #1d494e
+
+# OS Window titlebar colors
+wayland_titlebar_color #0e3c46
+macos_titlebar_color #0e3c46
+
+# Tab bar colors
 active_tab_background #0e3c46
 active_tab_foreground #c7dbdd
 inactive_tab_background #1d494e
 inactive_tab_foreground #9dc8cd
 tab_bar_background #1d494e
-wayland_titlebar_color #0e3c46
-macos_titlebar_color #0e3c46
 
+# The 16 terminal colors
 # normal
 color0 #0e3c46
 color1 #fb6953

--- a/colors/base16-silk-light.conf
+++ b/colors/base16-silk-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Silk Light
+## author:   Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Silk Light
+
 # Scheme name: base16 Silk Light
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #e9f1ef
 foreground #385156
 selection_background #5c787b
 selection_foreground #385156
-url_color #4b5b5f
+
+# Cursor colors
 cursor #385156
 cursor_text_color #e9f1ef
+
+# URL underline color when hovering with mouse
+url_color #4b5b5f
+
+# Kitty window border colors
 active_border_color #5c787b
 inactive_border_color #ccd4d3
+
+# OS Window titlebar colors
+wayland_titlebar_color #e9f1ef
+macos_titlebar_color #e9f1ef
+
+# Tab bar colors
 active_tab_background #e9f1ef
 active_tab_foreground #385156
 inactive_tab_background #ccd4d3
 inactive_tab_foreground #4b5b5f
 tab_bar_background #ccd4d3
-wayland_titlebar_color #e9f1ef
-macos_titlebar_color #e9f1ef
 
+# The 16 terminal colors
 # normal
 color0 #e9f1ef
 color1 #cf432e

--- a/colors/base16-snazzy.conf
+++ b/colors/base16-snazzy.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Snazzy
+## author:   Chawye Hsu (https://github.com/chawyehsu), based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Snazzy
+
 # Scheme name: base16 Snazzy
 # Scheme author: Chawye Hsu (https://github.com/chawyehsu), based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282a36
 foreground #e2e4e5
 selection_background #78787e
 selection_foreground #e2e4e5
-url_color #a5a5a9
+
+# Cursor colors
 cursor #e2e4e5
 cursor_text_color #282a36
+
+# URL underline color when hovering with mouse
+url_color #a5a5a9
+
+# Kitty window border colors
 active_border_color #78787e
 inactive_border_color #34353e
+
+# OS Window titlebar colors
+wayland_titlebar_color #282a36
+macos_titlebar_color #282a36
+
+# Tab bar colors
 active_tab_background #282a36
 active_tab_foreground #e2e4e5
 inactive_tab_background #34353e
 inactive_tab_foreground #a5a5a9
 tab_bar_background #34353e
-wayland_titlebar_color #282a36
-macos_titlebar_color #282a36
 
+# The 16 terminal colors
 # normal
 color0 #282a36
 color1 #ff5c57

--- a/colors/base16-solarflare-light.conf
+++ b/colors/base16-solarflare-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Solar Flare Light
+## author:   Chuck Harmston (https://chuck.harmston.ch)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Solar Flare Light
+
 # Scheme name: base16 Solar Flare Light
 # Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f5f7fa
 foreground #586875
 selection_background #85939e
 selection_foreground #586875
-url_color #667581
+
+# Cursor colors
 cursor #586875
 cursor_text_color #f5f7fa
+
+# URL underline color when hovering with mouse
+url_color #667581
+
+# Kitty window border colors
 active_border_color #85939e
 inactive_border_color #e8e9ed
+
+# OS Window titlebar colors
+wayland_titlebar_color #f5f7fa
+macos_titlebar_color #f5f7fa
+
+# Tab bar colors
 active_tab_background #f5f7fa
 active_tab_foreground #586875
 inactive_tab_background #e8e9ed
 inactive_tab_foreground #667581
 tab_bar_background #e8e9ed
-wayland_titlebar_color #f5f7fa
-macos_titlebar_color #f5f7fa
 
+# The 16 terminal colors
 # normal
 color0 #f5f7fa
 color1 #ef5253

--- a/colors/base16-solarflare.conf
+++ b/colors/base16-solarflare.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Solar Flare
+## author:   Chuck Harmston (https://chuck.harmston.ch)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Solar Flare
+
 # Scheme name: base16 Solar Flare
 # Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #18262f
 foreground #a6afb8
 selection_background #667581
 selection_foreground #a6afb8
-url_color #85939e
+
+# Cursor colors
 cursor #a6afb8
 cursor_text_color #18262f
+
+# URL underline color when hovering with mouse
+url_color #85939e
+
+# Kitty window border colors
 active_border_color #667581
 inactive_border_color #222e38
+
+# OS Window titlebar colors
+wayland_titlebar_color #18262f
+macos_titlebar_color #18262f
+
+# Tab bar colors
 active_tab_background #18262f
 active_tab_foreground #a6afb8
 inactive_tab_background #222e38
 inactive_tab_foreground #85939e
 tab_bar_background #222e38
-wayland_titlebar_color #18262f
-macos_titlebar_color #18262f
 
+# The 16 terminal colors
 # normal
 color0 #18262f
 color1 #ef5253

--- a/colors/base16-solarized-dark.conf
+++ b/colors/base16-solarized-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Solarized Dark
+## author:   Ethan Schoonover (modified by aramisgithub)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Solarized Dark
+
 # Scheme name: base16 Solarized Dark
 # Scheme author: Ethan Schoonover (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #002b36
 foreground #93a1a1
 selection_background #657b83
 selection_foreground #93a1a1
-url_color #839496
+
+# Cursor colors
 cursor #93a1a1
 cursor_text_color #002b36
+
+# URL underline color when hovering with mouse
+url_color #839496
+
+# Kitty window border colors
 active_border_color #657b83
 inactive_border_color #073642
+
+# OS Window titlebar colors
+wayland_titlebar_color #002b36
+macos_titlebar_color #002b36
+
+# Tab bar colors
 active_tab_background #002b36
 active_tab_foreground #93a1a1
 inactive_tab_background #073642
 inactive_tab_foreground #839496
 tab_bar_background #073642
-wayland_titlebar_color #002b36
-macos_titlebar_color #002b36
 
+# The 16 terminal colors
 # normal
 color0 #002b36
 color1 #dc322f

--- a/colors/base16-solarized-light.conf
+++ b/colors/base16-solarized-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Solarized Light
+## author:   Ethan Schoonover (modified by aramisgithub)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Solarized Light
+
 # Scheme name: base16 Solarized Light
 # Scheme author: Ethan Schoonover (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fdf6e3
 foreground #586e75
 selection_background #839496
 selection_foreground #586e75
-url_color #657b83
+
+# Cursor colors
 cursor #586e75
 cursor_text_color #fdf6e3
+
+# URL underline color when hovering with mouse
+url_color #657b83
+
+# Kitty window border colors
 active_border_color #839496
 inactive_border_color #eee8d5
+
+# OS Window titlebar colors
+wayland_titlebar_color #fdf6e3
+macos_titlebar_color #fdf6e3
+
+# Tab bar colors
 active_tab_background #fdf6e3
 active_tab_foreground #586e75
 inactive_tab_background #eee8d5
 inactive_tab_foreground #657b83
 tab_bar_background #eee8d5
-wayland_titlebar_color #fdf6e3
-macos_titlebar_color #fdf6e3
 
+# The 16 terminal colors
 # normal
 color0 #fdf6e3
 color1 #dc322f

--- a/colors/base16-spaceduck.conf
+++ b/colors/base16-spaceduck.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Spaceduck
+## author:   Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Spaceduck
+
 # Scheme name: base16 Spaceduck
 # Scheme author: Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #16172d
 foreground #ecf0c1
 selection_background #686f9a
 selection_foreground #ecf0c1
-url_color #818596
+
+# Cursor colors
 cursor #ecf0c1
 cursor_text_color #16172d
+
+# URL underline color when hovering with mouse
+url_color #818596
+
+# Kitty window border colors
 active_border_color #686f9a
 inactive_border_color #1b1c36
+
+# OS Window titlebar colors
+wayland_titlebar_color #16172d
+macos_titlebar_color #16172d
+
+# Tab bar colors
 active_tab_background #16172d
 active_tab_foreground #ecf0c1
 inactive_tab_background #1b1c36
 inactive_tab_foreground #818596
 tab_bar_background #1b1c36
-wayland_titlebar_color #16172d
-macos_titlebar_color #16172d
 
+# The 16 terminal colors
 # normal
 color0 #16172d
 color1 #e33400

--- a/colors/base16-spacemacs.conf
+++ b/colors/base16-spacemacs.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Spacemacs
+## author:   Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Spacemacs
+
 # Scheme name: base16 Spacemacs
 # Scheme author: Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1f2022
 foreground #a3a3a3
 selection_background #585858
 selection_foreground #a3a3a3
-url_color #b8b8b8
+
+# Cursor colors
 cursor #a3a3a3
 cursor_text_color #1f2022
+
+# URL underline color when hovering with mouse
+url_color #b8b8b8
+
+# Kitty window border colors
 active_border_color #585858
 inactive_border_color #282828
+
+# OS Window titlebar colors
+wayland_titlebar_color #1f2022
+macos_titlebar_color #1f2022
+
+# Tab bar colors
 active_tab_background #1f2022
 active_tab_foreground #a3a3a3
 inactive_tab_background #282828
 inactive_tab_foreground #b8b8b8
 tab_bar_background #282828
-wayland_titlebar_color #1f2022
-macos_titlebar_color #1f2022
 
+# The 16 terminal colors
 # normal
 color0 #1f2022
 color1 #f2241f

--- a/colors/base16-sparky.conf
+++ b/colors/base16-sparky.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Sparky
+## author:   Leila Sother (https://github.com/mixcoac)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Sparky
+
 # Scheme name: base16 Sparky
 # Scheme author: Leila Sother (https://github.com/mixcoac)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #072b31
 foreground #f4f5f0
 selection_background #003b49
 selection_foreground #f4f5f0
-url_color #00778b
+
+# Cursor colors
 cursor #f4f5f0
 cursor_text_color #072b31
+
+# URL underline color when hovering with mouse
+url_color #00778b
+
+# Kitty window border colors
 active_border_color #003b49
 inactive_border_color #00313c
+
+# OS Window titlebar colors
+wayland_titlebar_color #072b31
+macos_titlebar_color #072b31
+
+# Tab bar colors
 active_tab_background #072b31
 active_tab_foreground #f4f5f0
 inactive_tab_background #00313c
 inactive_tab_foreground #00778b
 tab_bar_background #00313c
-wayland_titlebar_color #072b31
-macos_titlebar_color #072b31
 
+# The 16 terminal colors
 # normal
 color0 #072b31
 color1 #ff585d

--- a/colors/base16-standardized-dark.conf
+++ b/colors/base16-standardized-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 standardized-dark
+## author:   ali (https://github.com/ali-githb/base16-standardized-scheme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    standardized-dark
+
 # Scheme name: base16 standardized-dark
 # Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #222222
 foreground #c0c0c0
 selection_background #898989
 selection_foreground #c0c0c0
-url_color #898989
+
+# Cursor colors
 cursor #c0c0c0
 cursor_text_color #222222
+
+# URL underline color when hovering with mouse
+url_color #898989
+
+# Kitty window border colors
 active_border_color #898989
 inactive_border_color #303030
+
+# OS Window titlebar colors
+wayland_titlebar_color #222222
+macos_titlebar_color #222222
+
+# Tab bar colors
 active_tab_background #222222
 active_tab_foreground #c0c0c0
 inactive_tab_background #303030
 inactive_tab_foreground #898989
 tab_bar_background #303030
-wayland_titlebar_color #222222
-macos_titlebar_color #222222
 
+# The 16 terminal colors
 # normal
 color0 #222222
 color1 #e15d67

--- a/colors/base16-standardized-light.conf
+++ b/colors/base16-standardized-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 standardized-light
+## author:   ali (https://github.com/ali-githb/base16-standardized-scheme)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    standardized-light
+
 # Scheme name: base16 standardized-light
 # Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #444444
 selection_background #767676
 selection_foreground #444444
-url_color #767676
+
+# Cursor colors
 cursor #444444
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #767676
+
+# Kitty window border colors
 active_border_color #767676
 inactive_border_color #eeeeee
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #444444
 inactive_tab_background #eeeeee
 inactive_tab_foreground #767676
 tab_bar_background #eeeeee
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #d03e3e

--- a/colors/base16-stella.conf
+++ b/colors/base16-stella.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Stella
+## author:   Shrimpram
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Stella
+
 # Scheme name: base16 Stella
 # Scheme author: Shrimpram
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2b213c
 foreground #998bad
 selection_background #655978
 selection_foreground #998bad
-url_color #7f7192
+
+# Cursor colors
 cursor #998bad
 cursor_text_color #2b213c
+
+# URL underline color when hovering with mouse
+url_color #7f7192
+
+# Kitty window border colors
 active_border_color #655978
 inactive_border_color #362b48
+
+# OS Window titlebar colors
+wayland_titlebar_color #2b213c
+macos_titlebar_color #2b213c
+
+# Tab bar colors
 active_tab_background #2b213c
 active_tab_foreground #998bad
 inactive_tab_background #362b48
 inactive_tab_foreground #7f7192
 tab_bar_background #362b48
-wayland_titlebar_color #2b213c
-macos_titlebar_color #2b213c
 
+# The 16 terminal colors
 # normal
 color0 #2b213c
 color1 #c79987

--- a/colors/base16-still-alive.conf
+++ b/colors/base16-still-alive.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Still Alive
+## author:   Derrick McKee (derrick.mckee@gmail.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Still Alive
+
 # Scheme name: base16 Still Alive
 # Scheme author: Derrick McKee (derrick.mckee@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f0f0f0
 foreground #d80000
 selection_background #f01818
 selection_foreground #d80000
-url_color #f00000
+
+# Cursor colors
 cursor #d80000
 cursor_text_color #f0f0f0
+
+# URL underline color when hovering with mouse
+url_color #f00000
+
+# Kitty window border colors
 active_border_color #f01818
 inactive_border_color #f0d848
+
+# OS Window titlebar colors
+wayland_titlebar_color #f0f0f0
+macos_titlebar_color #f0f0f0
+
+# Tab bar colors
 active_tab_background #f0f0f0
 active_tab_foreground #d80000
 inactive_tab_background #f0d848
 inactive_tab_foreground #f00000
 tab_bar_background #f0d848
-wayland_titlebar_color #f0f0f0
-macos_titlebar_color #f0f0f0
 
+# The 16 terminal colors
 # normal
 color0 #f0f0f0
 color1 #487830

--- a/colors/base16-summercamp.conf
+++ b/colors/base16-summercamp.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 summercamp
+## author:   zoe firi (zoefiri.github.io)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    summercamp
+
 # Scheme name: base16 summercamp
 # Scheme author: zoe firi (zoefiri.github.io)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1c1810
 foreground #736e55
 selection_background #504b38
 selection_foreground #736e55
-url_color #5f5b45
+
+# Cursor colors
 cursor #736e55
 cursor_text_color #1c1810
+
+# URL underline color when hovering with mouse
+url_color #5f5b45
+
+# Kitty window border colors
 active_border_color #504b38
 inactive_border_color #2a261c
+
+# OS Window titlebar colors
+wayland_titlebar_color #1c1810
+macos_titlebar_color #1c1810
+
+# Tab bar colors
 active_tab_background #1c1810
 active_tab_foreground #736e55
 inactive_tab_background #2a261c
 inactive_tab_foreground #5f5b45
 tab_bar_background #2a261c
-wayland_titlebar_color #1c1810
-macos_titlebar_color #1c1810
 
+# The 16 terminal colors
 # normal
 color0 #1c1810
 color1 #e35142

--- a/colors/base16-summerfruit-dark.conf
+++ b/colors/base16-summerfruit-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Summerfruit Dark
+## author:   Christopher Corley (http://christop.club/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Summerfruit Dark
+
 # Scheme name: base16 Summerfruit Dark
 # Scheme author: Christopher Corley (http://christop.club/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #151515
 foreground #d0d0d0
 selection_background #505050
 selection_foreground #d0d0d0
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #151515
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #151515
+macos_titlebar_color #151515
+
+# Tab bar colors
 active_tab_background #151515
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #151515
-macos_titlebar_color #151515
 
+# The 16 terminal colors
 # normal
 color0 #151515
 color1 #ff0086

--- a/colors/base16-summerfruit-light.conf
+++ b/colors/base16-summerfruit-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Summerfruit Light
+## author:   Christopher Corley (http://christop.club/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Summerfruit Light
+
 # Scheme name: base16 Summerfruit Light
 # Scheme author: Christopher Corley (http://christop.club/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #101010
 selection_background #b0b0b0
 selection_foreground #101010
-url_color #000000
+
+# Cursor colors
 cursor #101010
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #000000
+
+# Kitty window border colors
 active_border_color #b0b0b0
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #101010
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #000000
 tab_bar_background #e0e0e0
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #ff0086

--- a/colors/base16-synth-midnight-dark.conf
+++ b/colors/base16-synth-midnight-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Synth Midnight Terminal Dark
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Synth Midnight Terminal Dark
+
 # Scheme name: base16 Synth Midnight Terminal Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #050608
 foreground #c1c3c4
 selection_background #474849
 selection_foreground #c1c3c4
-url_color #a3a5a6
+
+# Cursor colors
 cursor #c1c3c4
 cursor_text_color #050608
+
+# URL underline color when hovering with mouse
+url_color #a3a5a6
+
+# Kitty window border colors
 active_border_color #474849
 inactive_border_color #1a1b1c
+
+# OS Window titlebar colors
+wayland_titlebar_color #050608
+macos_titlebar_color #050608
+
+# Tab bar colors
 active_tab_background #050608
 active_tab_foreground #c1c3c4
 inactive_tab_background #1a1b1c
 inactive_tab_foreground #a3a5a6
 tab_bar_background #1a1b1c
-wayland_titlebar_color #050608
-macos_titlebar_color #050608
 
+# The 16 terminal colors
 # normal
 color0 #050608
 color1 #b53b50

--- a/colors/base16-synth-midnight-light.conf
+++ b/colors/base16-synth-midnight-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Synth Midnight Terminal Light
+## author:   Michaël Ball (http://github.com/michael-ball/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Synth Midnight Terminal Light
+
 # Scheme name: base16 Synth Midnight Terminal Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #dddfe0
 foreground #28292a
 selection_background #a3a5a6
 selection_foreground #28292a
-url_color #474849
+
+# Cursor colors
 cursor #28292a
 cursor_text_color #dddfe0
+
+# URL underline color when hovering with mouse
+url_color #474849
+
+# Kitty window border colors
 active_border_color #a3a5a6
 inactive_border_color #cfd1d2
+
+# OS Window titlebar colors
+wayland_titlebar_color #dddfe0
+macos_titlebar_color #dddfe0
+
+# Tab bar colors
 active_tab_background #dddfe0
 active_tab_foreground #28292a
 inactive_tab_background #cfd1d2
 inactive_tab_foreground #474849
 tab_bar_background #cfd1d2
-wayland_titlebar_color #dddfe0
-macos_titlebar_color #dddfe0
 
+# The 16 terminal colors
 # normal
 color0 #dddfe0
 color1 #b53b50

--- a/colors/base16-tango.conf
+++ b/colors/base16-tango.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tango
+## author:   @Schnouki, based on the Tango Desktop Project
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tango
+
 # Scheme name: base16 Tango
 # Scheme author: @Schnouki, based on the Tango Desktop Project
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2e3436
 foreground #d3d7cf
 selection_background #555753
 selection_foreground #d3d7cf
-url_color #729fcf
+
+# Cursor colors
 cursor #d3d7cf
 cursor_text_color #2e3436
+
+# URL underline color when hovering with mouse
+url_color #729fcf
+
+# Kitty window border colors
 active_border_color #555753
 inactive_border_color #8ae234
+
+# OS Window titlebar colors
+wayland_titlebar_color #2e3436
+macos_titlebar_color #2e3436
+
+# Tab bar colors
 active_tab_background #2e3436
 active_tab_foreground #d3d7cf
 inactive_tab_background #8ae234
 inactive_tab_foreground #729fcf
 tab_bar_background #8ae234
-wayland_titlebar_color #2e3436
-macos_titlebar_color #2e3436
 
+# The 16 terminal colors
 # normal
 color0 #2e3436
 color1 #cc0000

--- a/colors/base16-tarot.conf
+++ b/colors/base16-tarot.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 tarot
+## author:   ed (https://codeberg.org/ed)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    tarot
+
 # Scheme name: base16 tarot
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0e091d
 foreground #aa556f
 selection_background #74316b
 selection_foreground #aa556f
-url_color #8c406f
+
+# Cursor colors
 cursor #aa556f
 cursor_text_color #0e091d
+
+# URL underline color when hovering with mouse
+url_color #8c406f
+
+# Kitty window border colors
 active_border_color #74316b
 inactive_border_color #2a153c
+
+# OS Window titlebar colors
+wayland_titlebar_color #0e091d
+macos_titlebar_color #0e091d
+
+# Tab bar colors
 active_tab_background #0e091d
 active_tab_foreground #aa556f
 inactive_tab_background #2a153c
 inactive_tab_foreground #8c406f
 tab_bar_background #2a153c
-wayland_titlebar_color #0e091d
-macos_titlebar_color #0e091d
 
+# The 16 terminal colors
 # normal
 color0 #0e091d
 color1 #c53253

--- a/colors/base16-tender.conf
+++ b/colors/base16-tender.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 tender
+## author:   Jacobo Tabernero (https://github/com/jacoborus/tender.vim)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    tender
+
 # Scheme name: base16 tender
 # Scheme author: Jacobo Tabernero (https://github/com/jacoborus/tender.vim)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282828
 foreground #eeeeee
 selection_background #4c4c4c
 selection_foreground #eeeeee
-url_color #b8b8b8
+
+# Cursor colors
 cursor #eeeeee
 cursor_text_color #282828
+
+# URL underline color when hovering with mouse
+url_color #b8b8b8
+
+# Kitty window border colors
 active_border_color #4c4c4c
 inactive_border_color #383838
+
+# OS Window titlebar colors
+wayland_titlebar_color #282828
+macos_titlebar_color #282828
+
+# Tab bar colors
 active_tab_background #282828
 active_tab_foreground #eeeeee
 inactive_tab_background #383838
 inactive_tab_foreground #b8b8b8
 tab_bar_background #383838
-wayland_titlebar_color #282828
-macos_titlebar_color #282828
 
+# The 16 terminal colors
 # normal
 color0 #282828
 color1 #f43753

--- a/colors/base16-terracotta-dark.conf
+++ b/colors/base16-terracotta-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Terracotta Dark
+## author:   Alexander Rossell Hayes (https://github.com/rossellhayes)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Terracotta Dark
+
 # Scheme name: base16 Terracotta Dark
 # Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #241d1a
 foreground #b8a59d
 selection_background #594740
 selection_foreground #b8a59d
-url_color #a78e84
+
+# Cursor colors
 cursor #b8a59d
 cursor_text_color #241d1a
+
+# URL underline color when hovering with mouse
+url_color #a78e84
+
+# Kitty window border colors
 active_border_color #594740
 inactive_border_color #362b27
+
+# OS Window titlebar colors
+wayland_titlebar_color #241d1a
+macos_titlebar_color #241d1a
+
+# Tab bar colors
 active_tab_background #241d1a
 active_tab_foreground #b8a59d
 inactive_tab_background #362b27
 inactive_tab_foreground #a78e84
 tab_bar_background #362b27
-wayland_titlebar_color #241d1a
-macos_titlebar_color #241d1a
 
+# The 16 terminal colors
 # normal
 color0 #241d1a
 color1 #f6998f

--- a/colors/base16-terracotta.conf
+++ b/colors/base16-terracotta.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Terracotta
+## author:   Alexander Rossell Hayes (https://github.com/rossellhayes)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Terracotta
+
 # Scheme name: base16 Terracotta
 # Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #efeae8
 foreground #473731
 selection_background #c0aca4
 selection_foreground #473731
-url_color #59453d
+
+# Cursor colors
 cursor #473731
 cursor_text_color #efeae8
+
+# URL underline color when hovering with mouse
+url_color #59453d
+
+# Kitty window border colors
 active_border_color #c0aca4
 inactive_border_color #dfd6d1
+
+# OS Window titlebar colors
+wayland_titlebar_color #efeae8
+macos_titlebar_color #efeae8
+
+# Tab bar colors
 active_tab_background #efeae8
 active_tab_foreground #473731
 inactive_tab_background #dfd6d1
 inactive_tab_foreground #59453d
 tab_bar_background #dfd6d1
-wayland_titlebar_color #efeae8
-macos_titlebar_color #efeae8
 
+# The 16 terminal colors
 # normal
 color0 #efeae8
 color1 #a75045

--- a/colors/base16-tokyo-city-dark.conf
+++ b/colors/base16-tokyo-city-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo City Dark
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo City Dark
+
 # Scheme name: base16 Tokyo City Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171d23
 foreground #d8e2ec
 selection_background #526270
 selection_foreground #d8e2ec
-url_color #b7c5d3
+
+# Cursor colors
 cursor #d8e2ec
 cursor_text_color #171d23
+
+# URL underline color when hovering with mouse
+url_color #b7c5d3
+
+# Kitty window border colors
 active_border_color #526270
 inactive_border_color #1d252c
+
+# OS Window titlebar colors
+wayland_titlebar_color #171d23
+macos_titlebar_color #171d23
+
+# Tab bar colors
 active_tab_background #171d23
 active_tab_foreground #d8e2ec
 inactive_tab_background #1d252c
 inactive_tab_foreground #b7c5d3
 tab_bar_background #1d252c
-wayland_titlebar_color #171d23
-macos_titlebar_color #171d23
 
+# The 16 terminal colors
 # normal
 color0 #171d23
 color1 #f7768e

--- a/colors/base16-tokyo-city-light.conf
+++ b/colors/base16-tokyo-city-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo City Light
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo City Light
+
 # Scheme name: base16 Tokyo City Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbfbfd
 foreground #343b59
 selection_background #9699a3
 selection_foreground #343b59
-url_color #4c505e
+
+# Cursor colors
 cursor #343b59
 cursor_text_color #fbfbfd
+
+# URL underline color when hovering with mouse
+url_color #4c505e
+
+# Kitty window border colors
 active_border_color #9699a3
 inactive_border_color #f6f6f8
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbfbfd
+macos_titlebar_color #fbfbfd
+
+# Tab bar colors
 active_tab_background #fbfbfd
 active_tab_foreground #343b59
 inactive_tab_background #f6f6f8
 inactive_tab_foreground #4c505e
 tab_bar_background #f6f6f8
-wayland_titlebar_color #fbfbfd
-macos_titlebar_color #fbfbfd
 
+# The 16 terminal colors
 # normal
 color0 #fbfbfd
 color1 #8c4351

--- a/colors/base16-tokyo-city-terminal-dark.conf
+++ b/colors/base16-tokyo-city-terminal-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo City Terminal Dark
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo City Terminal Dark
+
 # Scheme name: base16 Tokyo City Terminal Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #171d23
 foreground #d8e2ec
 selection_background #526270
 selection_foreground #d8e2ec
-url_color #b7c5d3
+
+# Cursor colors
 cursor #d8e2ec
 cursor_text_color #171d23
+
+# URL underline color when hovering with mouse
+url_color #b7c5d3
+
+# Kitty window border colors
 active_border_color #526270
 inactive_border_color #1d252c
+
+# OS Window titlebar colors
+wayland_titlebar_color #171d23
+macos_titlebar_color #171d23
+
+# Tab bar colors
 active_tab_background #171d23
 active_tab_foreground #d8e2ec
 inactive_tab_background #1d252c
 inactive_tab_foreground #b7c5d3
 tab_bar_background #1d252c
-wayland_titlebar_color #171d23
-macos_titlebar_color #171d23
 
+# The 16 terminal colors
 # normal
 color0 #171d23
 color1 #d95468

--- a/colors/base16-tokyo-city-terminal-light.conf
+++ b/colors/base16-tokyo-city-terminal-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo City Terminal Light
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo City Terminal Light
+
 # Scheme name: base16 Tokyo City Terminal Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fbfbfd
 foreground #28323a
 selection_background #b7c5d3
 selection_foreground #28323a
-url_color #526270
+
+# Cursor colors
 cursor #28323a
 cursor_text_color #fbfbfd
+
+# URL underline color when hovering with mouse
+url_color #526270
+
+# Kitty window border colors
 active_border_color #b7c5d3
 inactive_border_color #f6f6f8
+
+# OS Window titlebar colors
+wayland_titlebar_color #fbfbfd
+macos_titlebar_color #fbfbfd
+
+# Tab bar colors
 active_tab_background #fbfbfd
 active_tab_foreground #28323a
 inactive_tab_background #f6f6f8
 inactive_tab_foreground #526270
 tab_bar_background #f6f6f8
-wayland_titlebar_color #fbfbfd
-macos_titlebar_color #fbfbfd
 
+# The 16 terminal colors
 # normal
 color0 #fbfbfd
 color1 #8c4351

--- a/colors/base16-tokyo-night-dark.conf
+++ b/colors/base16-tokyo-night-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Dark
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Dark
+
 # Scheme name: base16 Tokyo Night Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1a1b26
 foreground #a9b1d6
 selection_background #444b6a
 selection_foreground #a9b1d6
-url_color #787c99
+
+# Cursor colors
 cursor #a9b1d6
 cursor_text_color #1a1b26
+
+# URL underline color when hovering with mouse
+url_color #787c99
+
+# Kitty window border colors
 active_border_color #444b6a
 inactive_border_color #16161e
+
+# OS Window titlebar colors
+wayland_titlebar_color #1a1b26
+macos_titlebar_color #1a1b26
+
+# Tab bar colors
 active_tab_background #1a1b26
 active_tab_foreground #a9b1d6
 inactive_tab_background #16161e
 inactive_tab_foreground #787c99
 tab_bar_background #16161e
-wayland_titlebar_color #1a1b26
-macos_titlebar_color #1a1b26
 
+# The 16 terminal colors
 # normal
 color0 #1a1b26
 color1 #c0caf5

--- a/colors/base16-tokyo-night-light.conf
+++ b/colors/base16-tokyo-night-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Light
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Light
+
 # Scheme name: base16 Tokyo Night Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #d5d6db
 foreground #343b59
 selection_background #9699a3
 selection_foreground #343b59
-url_color #4c505e
+
+# Cursor colors
 cursor #343b59
 cursor_text_color #d5d6db
+
+# URL underline color when hovering with mouse
+url_color #4c505e
+
+# Kitty window border colors
 active_border_color #9699a3
 inactive_border_color #cbccd1
+
+# OS Window titlebar colors
+wayland_titlebar_color #d5d6db
+macos_titlebar_color #d5d6db
+
+# Tab bar colors
 active_tab_background #d5d6db
 active_tab_foreground #343b59
 inactive_tab_background #cbccd1
 inactive_tab_foreground #4c505e
 tab_bar_background #cbccd1
-wayland_titlebar_color #d5d6db
-macos_titlebar_color #d5d6db
 
+# The 16 terminal colors
 # normal
 color0 #d5d6db
 color1 #343b58

--- a/colors/base16-tokyo-night-moon.conf
+++ b/colors/base16-tokyo-night-moon.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Moon
+## author:   Ólafur Bjarki Bogason
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Moon
+
 # Scheme name: base16 Tokyo Night Moon
 # Scheme author: Ólafur Bjarki Bogason
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #222436
 foreground #3b4261
 selection_background #636da6
 selection_foreground #3b4261
-url_color #828bb8
+
+# Cursor colors
 cursor #3b4261
 cursor_text_color #222436
+
+# URL underline color when hovering with mouse
+url_color #828bb8
+
+# Kitty window border colors
 active_border_color #636da6
 inactive_border_color #1e2030
+
+# OS Window titlebar colors
+wayland_titlebar_color #222436
+macos_titlebar_color #222436
+
+# Tab bar colors
 active_tab_background #222436
 active_tab_foreground #3b4261
 inactive_tab_background #1e2030
 inactive_tab_foreground #828bb8
 tab_bar_background #1e2030
-wayland_titlebar_color #222436
-macos_titlebar_color #222436
 
+# The 16 terminal colors
 # normal
 color0 #222436
 color1 #ff757f

--- a/colors/base16-tokyo-night-storm.conf
+++ b/colors/base16-tokyo-night-storm.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Storm
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Storm
+
 # Scheme name: base16 Tokyo Night Storm
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #24283b
 foreground #a9b1d6
 selection_background #444b6a
 selection_foreground #a9b1d6
-url_color #787c99
+
+# Cursor colors
 cursor #a9b1d6
 cursor_text_color #24283b
+
+# URL underline color when hovering with mouse
+url_color #787c99
+
+# Kitty window border colors
 active_border_color #444b6a
 inactive_border_color #16161e
+
+# OS Window titlebar colors
+wayland_titlebar_color #24283b
+macos_titlebar_color #24283b
+
+# Tab bar colors
 active_tab_background #24283b
 active_tab_foreground #a9b1d6
 inactive_tab_background #16161e
 inactive_tab_foreground #787c99
 tab_bar_background #16161e
-wayland_titlebar_color #24283b
-macos_titlebar_color #24283b
 
+# The 16 terminal colors
 # normal
 color0 #24283b
 color1 #c0caf5

--- a/colors/base16-tokyo-night-terminal-dark.conf
+++ b/colors/base16-tokyo-night-terminal-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Terminal Dark
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Terminal Dark
+
 # Scheme name: base16 Tokyo Night Terminal Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #16161e
 foreground #787c99
 selection_background #444b6a
 selection_foreground #787c99
-url_color #787c99
+
+# Cursor colors
 cursor #787c99
 cursor_text_color #16161e
+
+# URL underline color when hovering with mouse
+url_color #787c99
+
+# Kitty window border colors
 active_border_color #444b6a
 inactive_border_color #1a1b26
+
+# OS Window titlebar colors
+wayland_titlebar_color #16161e
+macos_titlebar_color #16161e
+
+# Tab bar colors
 active_tab_background #16161e
 active_tab_foreground #787c99
 inactive_tab_background #1a1b26
 inactive_tab_foreground #787c99
 tab_bar_background #1a1b26
-wayland_titlebar_color #16161e
-macos_titlebar_color #16161e
 
+# The 16 terminal colors
 # normal
 color0 #16161e
 color1 #f7768e

--- a/colors/base16-tokyo-night-terminal-light.conf
+++ b/colors/base16-tokyo-night-terminal-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Terminal Light
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Terminal Light
+
 # Scheme name: base16 Tokyo Night Terminal Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #d5d6db
 foreground #4c505e
 selection_background #9699a3
 selection_foreground #4c505e
-url_color #4c505e
+
+# Cursor colors
 cursor #4c505e
 cursor_text_color #d5d6db
+
+# URL underline color when hovering with mouse
+url_color #4c505e
+
+# Kitty window border colors
 active_border_color #9699a3
 inactive_border_color #cbccd1
+
+# OS Window titlebar colors
+wayland_titlebar_color #d5d6db
+macos_titlebar_color #d5d6db
+
+# Tab bar colors
 active_tab_background #d5d6db
 active_tab_foreground #4c505e
 inactive_tab_background #cbccd1
 inactive_tab_foreground #4c505e
 tab_bar_background #cbccd1
-wayland_titlebar_color #d5d6db
-macos_titlebar_color #d5d6db
 
+# The 16 terminal colors
 # normal
 color0 #d5d6db
 color1 #8c4351

--- a/colors/base16-tokyo-night-terminal-storm.conf
+++ b/colors/base16-tokyo-night-terminal-storm.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyo Night Terminal Storm
+## author:   Michaël Ball
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyo Night Terminal Storm
+
 # Scheme name: base16 Tokyo Night Terminal Storm
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #24283b
 foreground #787c99
 selection_background #444b6a
 selection_foreground #787c99
-url_color #787c99
+
+# Cursor colors
 cursor #787c99
 cursor_text_color #24283b
+
+# URL underline color when hovering with mouse
+url_color #787c99
+
+# Kitty window border colors
 active_border_color #444b6a
 inactive_border_color #1a1b26
+
+# OS Window titlebar colors
+wayland_titlebar_color #24283b
+macos_titlebar_color #24283b
+
+# Tab bar colors
 active_tab_background #24283b
 active_tab_foreground #787c99
 inactive_tab_background #1a1b26
 inactive_tab_foreground #787c99
 tab_bar_background #1a1b26
-wayland_titlebar_color #24283b
-macos_titlebar_color #24283b
 
+# The 16 terminal colors
 # normal
 color0 #24283b
 color1 #f7768e

--- a/colors/base16-tokyodark-terminal.conf
+++ b/colors/base16-tokyodark-terminal.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyodark Terminal
+## author:   Tiagovla (https://github.com/tiagovla/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyodark Terminal
+
 # Scheme name: base16 Tokyodark Terminal
 # Scheme author: Tiagovla (https://github.com/tiagovla/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #11121d
 foreground #a0a8cd
 selection_background #282c34
 selection_foreground #a0a8cd
-url_color #4a5057
+
+# Cursor colors
 cursor #a0a8cd
 cursor_text_color #11121d
+
+# URL underline color when hovering with mouse
+url_color #4a5057
+
+# Kitty window border colors
 active_border_color #282c34
 inactive_border_color #1a1b2a
+
+# OS Window titlebar colors
+wayland_titlebar_color #11121d
+macos_titlebar_color #11121d
+
+# Tab bar colors
 active_tab_background #11121d
 active_tab_foreground #a0a8cd
 inactive_tab_background #1a1b2a
 inactive_tab_foreground #4a5057
 tab_bar_background #1a1b2a
-wayland_titlebar_color #11121d
-macos_titlebar_color #11121d
 
+# The 16 terminal colors
 # normal
 color0 #11121d
 color1 #ee6d85

--- a/colors/base16-tokyodark.conf
+++ b/colors/base16-tokyodark.conf
@@ -1,48 +1,68 @@
+# vim:ft=kitty
+
+## name:     base16 Tokyodark
+## author:   Tiagovla (https://github.com/tiagovla/)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tokyodark
+
 # Scheme name: base16 Tokyodark
-# Scheme author: Jamy Golden (https://github.com/JamyGolden), Based on Tokyodark.nvim (https://github.com/tiagovla/tokyodark.nvim)
+# Scheme author: Tiagovla (https://github.com/tiagovla/)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #11121d
-foreground #a0a8cd
-selection_background #353945
-selection_foreground #a0a8cd
-url_color #4a5057
-cursor #a0a8cd
+foreground #abb2bf
+selection_background #393a45
+selection_foreground #abb2bf
+
+# Cursor colors
+cursor #abb2bf
 cursor_text_color #11121d
-active_border_color #353945
-inactive_border_color #212234
-active_tab_background #11121d
-active_tab_foreground #a0a8cd
-inactive_tab_background #212234
-inactive_tab_foreground #4a5057
-tab_bar_background #212234
+
+# URL underline color when hovering with mouse
+url_color #1b1c27
+
+# Kitty window border colors
+active_border_color #393a45
+inactive_border_color #151621
+
+# OS Window titlebar colors
 wayland_titlebar_color #11121d
 macos_titlebar_color #11121d
 
+# Tab bar colors
+active_tab_background #11121d
+active_tab_foreground #abb2bf
+inactive_tab_background #151621
+inactive_tab_foreground #1b1c27
+tab_bar_background #151621
+
+# The 16 terminal colors
 # normal
 color0 #11121d
-color1 #ee6d85
-color2 #95c561
-color3 #d7a65f
-color4 #7199ee
-color5 #a485dd
-color6 #9fbbf3
-color7 #a0a8cd
+color1 #a485dd
+color2 #d7a65f
+color3 #7199ee
+color4 #95c561
+color5 #ee6d85
+color6 #a485dd
+color7 #abb2bf
 
 # bright
-color8 #212234
-color9 #ee6d85
-color10 #95c561
-color11 #d7a65f
-color12 #7199ee
-color13 #a485dd
-color14 #9fbbf3
-color15 #bcc2dc
+color8 #43444f
+color9 #a485dd
+color10 #d7a65f
+color11 #7199ee
+color12 #95c561
+color13 #ee6d85
+color14 #a485dd
+color15 #2c2d38
 
 # extended base16 colors
-color16 #f6955b
+color16 #a485dd
 color17 #773440
-color18 #212234
-color19 #212234
-color20 #4a5057
-color21 #abb2bf
+color18 #151621
+color19 #43444f
+color20 #1b1c27
+color21 #555661

--- a/colors/base16-tomorrow-night-eighties.conf
+++ b/colors/base16-tomorrow-night-eighties.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tomorrow Night Eighties
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tomorrow Night Eighties
+
 # Scheme name: base16 Tomorrow Night Eighties
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2d2d2d
 foreground #cccccc
 selection_background #999999
 selection_foreground #cccccc
-url_color #b4b7b4
+
+# Cursor colors
 cursor #cccccc
 cursor_text_color #2d2d2d
+
+# URL underline color when hovering with mouse
+url_color #b4b7b4
+
+# Kitty window border colors
 active_border_color #999999
 inactive_border_color #393939
+
+# OS Window titlebar colors
+wayland_titlebar_color #2d2d2d
+macos_titlebar_color #2d2d2d
+
+# Tab bar colors
 active_tab_background #2d2d2d
 active_tab_foreground #cccccc
 inactive_tab_background #393939
 inactive_tab_foreground #b4b7b4
 tab_bar_background #393939
-wayland_titlebar_color #2d2d2d
-macos_titlebar_color #2d2d2d
 
+# The 16 terminal colors
 # normal
 color0 #2d2d2d
 color1 #f2777a

--- a/colors/base16-tomorrow-night.conf
+++ b/colors/base16-tomorrow-night.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tomorrow Night
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tomorrow Night
+
 # Scheme name: base16 Tomorrow Night
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1d1f21
 foreground #c5c8c6
 selection_background #969896
 selection_foreground #c5c8c6
-url_color #b4b7b4
+
+# Cursor colors
 cursor #c5c8c6
 cursor_text_color #1d1f21
+
+# URL underline color when hovering with mouse
+url_color #b4b7b4
+
+# Kitty window border colors
 active_border_color #969896
 inactive_border_color #282a2e
+
+# OS Window titlebar colors
+wayland_titlebar_color #1d1f21
+macos_titlebar_color #1d1f21
+
+# Tab bar colors
 active_tab_background #1d1f21
 active_tab_foreground #c5c8c6
 inactive_tab_background #282a2e
 inactive_tab_foreground #b4b7b4
 tab_bar_background #282a2e
-wayland_titlebar_color #1d1f21
-macos_titlebar_color #1d1f21
 
+# The 16 terminal colors
 # normal
 color0 #1d1f21
 color1 #cc6666

--- a/colors/base16-tomorrow.conf
+++ b/colors/base16-tomorrow.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Tomorrow
+## author:   Chris Kempson (http://chriskempson.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Tomorrow
+
 # Scheme name: base16 Tomorrow
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #4d4d4c
 selection_background #8e908c
 selection_foreground #4d4d4c
-url_color #969896
+
+# Cursor colors
 cursor #4d4d4c
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #969896
+
+# Kitty window border colors
 active_border_color #8e908c
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #4d4d4c
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #969896
 tab_bar_background #e0e0e0
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #c82829

--- a/colors/base16-tube.conf
+++ b/colors/base16-tube.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 London Tube
+## author:   Jan T. Sott
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    London Tube
+
 # Scheme name: base16 London Tube
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #231f20
 foreground #d9d8d8
 selection_background #737171
 selection_foreground #d9d8d8
-url_color #959ca1
+
+# Cursor colors
 cursor #d9d8d8
 cursor_text_color #231f20
+
+# URL underline color when hovering with mouse
+url_color #959ca1
+
+# Kitty window border colors
 active_border_color #737171
 inactive_border_color #1c3f95
+
+# OS Window titlebar colors
+wayland_titlebar_color #231f20
+macos_titlebar_color #231f20
+
+# Tab bar colors
 active_tab_background #231f20
 active_tab_foreground #d9d8d8
 inactive_tab_background #1c3f95
 inactive_tab_foreground #959ca1
 tab_bar_background #1c3f95
-wayland_titlebar_color #231f20
-macos_titlebar_color #231f20
 
+# The 16 terminal colors
 # normal
 color0 #231f20
 color1 #ee2e24

--- a/colors/base16-twilight.conf
+++ b/colors/base16-twilight.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Twilight
+## author:   David Hart (https://github.com/hartbit)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Twilight
+
 # Scheme name: base16 Twilight
 # Scheme author: David Hart (https://github.com/hartbit)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #1e1e1e
 foreground #a7a7a7
 selection_background #5f5a60
 selection_foreground #a7a7a7
-url_color #838184
+
+# Cursor colors
 cursor #a7a7a7
 cursor_text_color #1e1e1e
+
+# URL underline color when hovering with mouse
+url_color #838184
+
+# Kitty window border colors
 active_border_color #5f5a60
 inactive_border_color #323537
+
+# OS Window titlebar colors
+wayland_titlebar_color #1e1e1e
+macos_titlebar_color #1e1e1e
+
+# Tab bar colors
 active_tab_background #1e1e1e
 active_tab_foreground #a7a7a7
 inactive_tab_background #323537
 inactive_tab_foreground #838184
 tab_bar_background #323537
-wayland_titlebar_color #1e1e1e
-macos_titlebar_color #1e1e1e
 
+# The 16 terminal colors
 # normal
 color0 #1e1e1e
 color1 #cf6a4c

--- a/colors/base16-unikitty-dark.conf
+++ b/colors/base16-unikitty-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Unikitty Dark
+## author:   Josh W Lewis (@joshwlewis)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Unikitty Dark
+
 # Scheme name: base16 Unikitty Dark
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2e2a31
 foreground #bcbabe
 selection_background #838085
 selection_foreground #bcbabe
-url_color #9f9da2
+
+# Cursor colors
 cursor #bcbabe
 cursor_text_color #2e2a31
+
+# URL underline color when hovering with mouse
+url_color #9f9da2
+
+# Kitty window border colors
 active_border_color #838085
 inactive_border_color #4a464d
+
+# OS Window titlebar colors
+wayland_titlebar_color #2e2a31
+macos_titlebar_color #2e2a31
+
+# Tab bar colors
 active_tab_background #2e2a31
 active_tab_foreground #bcbabe
 inactive_tab_background #4a464d
 inactive_tab_foreground #9f9da2
 tab_bar_background #4a464d
-wayland_titlebar_color #2e2a31
-macos_titlebar_color #2e2a31
 
+# The 16 terminal colors
 # normal
 color0 #2e2a31
 color1 #d8137f

--- a/colors/base16-unikitty-light.conf
+++ b/colors/base16-unikitty-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Unikitty Light
+## author:   Josh W Lewis (@joshwlewis)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Unikitty Light
+
 # Scheme name: base16 Unikitty Light
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #6c696e
 selection_background #a7a5a8
 selection_foreground #6c696e
-url_color #89878b
+
+# Cursor colors
 cursor #6c696e
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #89878b
+
+# Kitty window border colors
 active_border_color #a7a5a8
 inactive_border_color #e1e1e2
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #6c696e
 inactive_tab_background #e1e1e2
 inactive_tab_foreground #89878b
 tab_bar_background #e1e1e2
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #d8137f

--- a/colors/base16-unikitty-reversible.conf
+++ b/colors/base16-unikitty-reversible.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Unikitty Reversible
+## author:   Josh W Lewis (@joshwlewis)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Unikitty Reversible
+
 # Scheme name: base16 Unikitty Reversible
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #2e2a31
 foreground #c3c2c4
 selection_background #878589
 selection_foreground #c3c2c4
-url_color #a5a3a6
+
+# Cursor colors
 cursor #c3c2c4
 cursor_text_color #2e2a31
+
+# URL underline color when hovering with mouse
+url_color #a5a3a6
+
+# Kitty window border colors
 active_border_color #878589
 inactive_border_color #4b484e
+
+# OS Window titlebar colors
+wayland_titlebar_color #2e2a31
+macos_titlebar_color #2e2a31
+
+# Tab bar colors
 active_tab_background #2e2a31
 active_tab_foreground #c3c2c4
 inactive_tab_background #4b484e
 inactive_tab_foreground #a5a3a6
 tab_bar_background #4b484e
-wayland_titlebar_color #2e2a31
-macos_titlebar_color #2e2a31
 
+# The 16 terminal colors
 # normal
 color0 #2e2a31
 color1 #d8137f

--- a/colors/base16-uwunicorn.conf
+++ b/colors/base16-uwunicorn.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 UwUnicorn
+## author:   Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    UwUnicorn
+
 # Scheme name: base16 UwUnicorn
 # Scheme author: Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #241b26
 foreground #eed5d9
 selection_background #6c3cb2
 selection_foreground #eed5d9
-url_color #7e5f83
+
+# Cursor colors
 cursor #eed5d9
 cursor_text_color #241b26
+
+# URL underline color when hovering with mouse
+url_color #7e5f83
+
+# Kitty window border colors
 active_border_color #6c3cb2
 inactive_border_color #2f2a3f
+
+# OS Window titlebar colors
+wayland_titlebar_color #241b26
+macos_titlebar_color #241b26
+
+# Tab bar colors
 active_tab_background #241b26
 active_tab_foreground #eed5d9
 inactive_tab_background #2f2a3f
 inactive_tab_foreground #7e5f83
 tab_bar_background #2f2a3f
-wayland_titlebar_color #241b26
-macos_titlebar_color #241b26
 
+# The 16 terminal colors
 # normal
 color0 #241b26
 color1 #877bb6

--- a/colors/base16-vesper.conf
+++ b/colors/base16-vesper.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Vesper
+## author:   FormalSnake (https://github.com/formalsnake)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Vesper
+
 # Scheme name: base16 Vesper
 # Scheme author: FormalSnake (https://github.com/formalsnake)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #101010
 foreground #b7b7b7
 selection_background #333333
 selection_foreground #b7b7b7
-url_color #999999
+
+# Cursor colors
 cursor #b7b7b7
 cursor_text_color #101010
+
+# URL underline color when hovering with mouse
+url_color #999999
+
+# Kitty window border colors
 active_border_color #333333
 inactive_border_color #232323
+
+# OS Window titlebar colors
+wayland_titlebar_color #101010
+macos_titlebar_color #101010
+
+# Tab bar colors
 active_tab_background #101010
 active_tab_foreground #b7b7b7
 inactive_tab_background #232323
 inactive_tab_foreground #999999
 tab_bar_background #232323
-wayland_titlebar_color #101010
-macos_titlebar_color #101010
 
+# The 16 terminal colors
 # normal
 color0 #101010
 color1 #de6e6e

--- a/colors/base16-vice.conf
+++ b/colors/base16-vice.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 vice
+## author:   Thomas Leon Highbaugh thighbaugh@zoho.com
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    vice
+
 # Scheme name: base16 vice
 # Scheme author: Thomas Leon Highbaugh thighbaugh@zoho.com
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #17191e
 foreground #8b9cbe
 selection_background #383a47
 selection_foreground #8b9cbe
-url_color #555e70
+
+# Cursor colors
 cursor #8b9cbe
 cursor_text_color #17191e
+
+# URL underline color when hovering with mouse
+url_color #555e70
+
+# Kitty window border colors
 active_border_color #383a47
 inactive_border_color #22262d
+
+# OS Window titlebar colors
+wayland_titlebar_color #17191e
+macos_titlebar_color #17191e
+
+# Tab bar colors
 active_tab_background #17191e
 active_tab_foreground #8b9cbe
 inactive_tab_background #22262d
 inactive_tab_foreground #555e70
 tab_bar_background #22262d
-wayland_titlebar_color #17191e
-macos_titlebar_color #17191e
 
+# The 16 terminal colors
 # normal
 color0 #17191e
 color1 #ff29a8

--- a/colors/base16-vulcan.conf
+++ b/colors/base16-vulcan.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 vulcan
+## author:   Andrey Varfolomeev
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    vulcan
+
 # Scheme name: base16 vulcan
 # Scheme author: Andrey Varfolomeev
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #041523
 foreground #5b778c
 selection_background #7a5759
 selection_foreground #5b778c
-url_color #6b6977
+
+# Cursor colors
 cursor #5b778c
 cursor_text_color #041523
+
+# URL underline color when hovering with mouse
+url_color #6b6977
+
+# Kitty window border colors
 active_border_color #7a5759
 inactive_border_color #122339
+
+# OS Window titlebar colors
+wayland_titlebar_color #041523
+macos_titlebar_color #041523
+
+# Tab bar colors
 active_tab_background #041523
 active_tab_foreground #5b778c
 inactive_tab_background #122339
 inactive_tab_foreground #6b6977
 tab_bar_background #122339
-wayland_titlebar_color #041523
-macos_titlebar_color #041523
 
+# The 16 terminal colors
 # normal
 color0 #041523
 color1 #818591

--- a/colors/base16-windows-10-light.conf
+++ b/colors/base16-windows-10-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows 10 Light
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows 10 Light
+
 # Scheme name: base16 Windows 10 Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f2f2f2
 foreground #767676
 selection_background #cccccc
 selection_foreground #767676
-url_color #ababab
+
+# Cursor colors
 cursor #767676
 cursor_text_color #f2f2f2
+
+# URL underline color when hovering with mouse
+url_color #ababab
+
+# Kitty window border colors
 active_border_color #cccccc
 inactive_border_color #e5e5e5
+
+# OS Window titlebar colors
+wayland_titlebar_color #f2f2f2
+macos_titlebar_color #f2f2f2
+
+# Tab bar colors
 active_tab_background #f2f2f2
 active_tab_foreground #767676
 inactive_tab_background #e5e5e5
 inactive_tab_foreground #ababab
 tab_bar_background #e5e5e5
-wayland_titlebar_color #f2f2f2
-macos_titlebar_color #f2f2f2
 
+# The 16 terminal colors
 # normal
 color0 #f2f2f2
 color1 #c50f1f

--- a/colors/base16-windows-10.conf
+++ b/colors/base16-windows-10.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows 10
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows 10
+
 # Scheme name: base16 Windows 10
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #0c0c0c
 foreground #cccccc
 selection_background #767676
 selection_foreground #cccccc
-url_color #b9b9b9
+
+# Cursor colors
 cursor #cccccc
 cursor_text_color #0c0c0c
+
+# URL underline color when hovering with mouse
+url_color #b9b9b9
+
+# Kitty window border colors
 active_border_color #767676
 inactive_border_color #2f2f2f
+
+# OS Window titlebar colors
+wayland_titlebar_color #0c0c0c
+macos_titlebar_color #0c0c0c
+
+# Tab bar colors
 active_tab_background #0c0c0c
 active_tab_foreground #cccccc
 inactive_tab_background #2f2f2f
 inactive_tab_foreground #b9b9b9
 tab_bar_background #2f2f2f
-wayland_titlebar_color #0c0c0c
-macos_titlebar_color #0c0c0c
 
+# The 16 terminal colors
 # normal
 color0 #0c0c0c
 color1 #e74856

--- a/colors/base16-windows-95-light.conf
+++ b/colors/base16-windows-95-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows 95 Light
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows 95 Light
+
 # Scheme name: base16 Windows 95 Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fcfcfc
 foreground #545454
 selection_background #a8a8a8
 selection_foreground #545454
-url_color #7e7e7e
+
+# Cursor colors
 cursor #545454
 cursor_text_color #fcfcfc
+
+# URL underline color when hovering with mouse
+url_color #7e7e7e
+
+# Kitty window border colors
 active_border_color #a8a8a8
 inactive_border_color #e0e0e0
+
+# OS Window titlebar colors
+wayland_titlebar_color #fcfcfc
+macos_titlebar_color #fcfcfc
+
+# Tab bar colors
 active_tab_background #fcfcfc
 active_tab_foreground #545454
 inactive_tab_background #e0e0e0
 inactive_tab_foreground #7e7e7e
 tab_bar_background #e0e0e0
-wayland_titlebar_color #fcfcfc
-macos_titlebar_color #fcfcfc
 
+# The 16 terminal colors
 # normal
 color0 #fcfcfc
 color1 #a80000

--- a/colors/base16-windows-95.conf
+++ b/colors/base16-windows-95.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows 95
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows 95
+
 # Scheme name: base16 Windows 95
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #a8a8a8
 selection_background #545454
 selection_foreground #a8a8a8
-url_color #7e7e7e
+
+# Cursor colors
 cursor #a8a8a8
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #7e7e7e
+
+# Kitty window border colors
 active_border_color #545454
 inactive_border_color #1c1c1c
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #a8a8a8
 inactive_tab_background #1c1c1c
 inactive_tab_foreground #7e7e7e
 tab_bar_background #1c1c1c
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #fc5454

--- a/colors/base16-windows-highcontrast-light.conf
+++ b/colors/base16-windows-highcontrast-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows High Contrast Light
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows High Contrast Light
+
 # Scheme name: base16 Windows High Contrast Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #fcfcfc
 foreground #545454
 selection_background #c0c0c0
 selection_foreground #545454
-url_color #7e7e7e
+
+# Cursor colors
 cursor #545454
 cursor_text_color #fcfcfc
+
+# URL underline color when hovering with mouse
+url_color #7e7e7e
+
+# Kitty window border colors
 active_border_color #c0c0c0
 inactive_border_color #e8e8e8
+
+# OS Window titlebar colors
+wayland_titlebar_color #fcfcfc
+macos_titlebar_color #fcfcfc
+
+# Tab bar colors
 active_tab_background #fcfcfc
 active_tab_foreground #545454
 inactive_tab_background #e8e8e8
 inactive_tab_foreground #7e7e7e
 tab_bar_background #e8e8e8
-wayland_titlebar_color #fcfcfc
-macos_titlebar_color #fcfcfc
 
+# The 16 terminal colors
 # normal
 color0 #fcfcfc
 color1 #800000

--- a/colors/base16-windows-highcontrast.conf
+++ b/colors/base16-windows-highcontrast.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows High Contrast
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows High Contrast
+
 # Scheme name: base16 Windows High Contrast
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c0c0c0
 selection_background #545454
 selection_foreground #c0c0c0
-url_color #a2a2a2
+
+# Cursor colors
 cursor #c0c0c0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #a2a2a2
+
+# Kitty window border colors
 active_border_color #545454
 inactive_border_color #1c1c1c
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c0c0c0
 inactive_tab_background #1c1c1c
 inactive_tab_foreground #a2a2a2
 tab_bar_background #1c1c1c
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #fc5454

--- a/colors/base16-windows-nt-light.conf
+++ b/colors/base16-windows-nt-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows NT Light
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows NT Light
+
 # Scheme name: base16 Windows NT Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #ffffff
 foreground #808080
 selection_background #c0c0c0
 selection_foreground #808080
-url_color #a0a0a0
+
+# Cursor colors
 cursor #808080
 cursor_text_color #ffffff
+
+# URL underline color when hovering with mouse
+url_color #a0a0a0
+
+# Kitty window border colors
 active_border_color #c0c0c0
 inactive_border_color #eaeaea
+
+# OS Window titlebar colors
+wayland_titlebar_color #ffffff
+macos_titlebar_color #ffffff
+
+# Tab bar colors
 active_tab_background #ffffff
 active_tab_foreground #808080
 inactive_tab_background #eaeaea
 inactive_tab_foreground #a0a0a0
 tab_bar_background #eaeaea
-wayland_titlebar_color #ffffff
-macos_titlebar_color #ffffff
 
+# The 16 terminal colors
 # normal
 color0 #ffffff
 color1 #800000

--- a/colors/base16-windows-nt.conf
+++ b/colors/base16-windows-nt.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Windows NT
+## author:   Fergus Collins (https://github.com/C-Fergus)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Windows NT
+
 # Scheme name: base16 Windows NT
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #c0c0c0
 selection_background #808080
 selection_foreground #c0c0c0
-url_color #a1a1a1
+
+# Cursor colors
 cursor #c0c0c0
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #a1a1a1
+
+# Kitty window border colors
 active_border_color #808080
 inactive_border_color #2a2a2a
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #c0c0c0
 inactive_tab_background #2a2a2a
 inactive_tab_foreground #a1a1a1
 tab_bar_background #2a2a2a
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #ff0000

--- a/colors/base16-woodland.conf
+++ b/colors/base16-woodland.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Woodland
+## author:   Jay Cornwall (https://jcornwall.com)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Woodland
+
 # Scheme name: base16 Woodland
 # Scheme author: Jay Cornwall (https://jcornwall.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #231e18
 foreground #cabcb1
 selection_background #9d8b70
 selection_foreground #cabcb1
-url_color #b4a490
+
+# Cursor colors
 cursor #cabcb1
 cursor_text_color #231e18
+
+# URL underline color when hovering with mouse
+url_color #b4a490
+
+# Kitty window border colors
 active_border_color #9d8b70
 inactive_border_color #302b25
+
+# OS Window titlebar colors
+wayland_titlebar_color #231e18
+macos_titlebar_color #231e18
+
+# Tab bar colors
 active_tab_background #231e18
 active_tab_foreground #cabcb1
 inactive_tab_background #302b25
 inactive_tab_foreground #b4a490
 tab_bar_background #302b25
-wayland_titlebar_color #231e18
-macos_titlebar_color #231e18
 
+# The 16 terminal colors
 # normal
 color0 #231e18
 color1 #d35c5c

--- a/colors/base16-xcode-dusk.conf
+++ b/colors/base16-xcode-dusk.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 XCode Dusk
+## author:   Elsa Gonsiorowski (https://github.com/gonsie)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    XCode Dusk
+
 # Scheme name: base16 XCode Dusk
 # Scheme author: Elsa Gonsiorowski (https://github.com/gonsie)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282b35
 foreground #939599
 selection_background #686a71
 selection_foreground #939599
-url_color #7e8086
+
+# Cursor colors
 cursor #939599
 cursor_text_color #282b35
+
+# URL underline color when hovering with mouse
+url_color #7e8086
+
+# Kitty window border colors
 active_border_color #686a71
 inactive_border_color #3d4048
+
+# OS Window titlebar colors
+wayland_titlebar_color #282b35
+macos_titlebar_color #282b35
+
+# Tab bar colors
 active_tab_background #282b35
 active_tab_foreground #939599
 inactive_tab_background #3d4048
 inactive_tab_foreground #7e8086
 tab_bar_background #3d4048
-wayland_titlebar_color #282b35
-macos_titlebar_color #282b35
 
+# The 16 terminal colors
 # normal
 color0 #282b35
 color1 #b21889

--- a/colors/base16-zenbones.conf
+++ b/colors/base16-zenbones.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Zenbones
+## author:   mcchrish
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Zenbones
+
 # Scheme name: base16 Zenbones
 # Scheme author: mcchrish
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #191919
 foreground #b279a7
 selection_background #b77e64
 selection_foreground #b279a7
-url_color #6099c0
+
+# Cursor colors
 cursor #b279a7
 cursor_text_color #191919
+
+# URL underline color when hovering with mouse
+url_color #6099c0
+
+# Kitty window border colors
 active_border_color #b77e64
 inactive_border_color #de6e7c
+
+# OS Window titlebar colors
+wayland_titlebar_color #191919
+macos_titlebar_color #191919
+
+# Tab bar colors
 active_tab_background #191919
 active_tab_foreground #b279a7
 inactive_tab_background #de6e7c
 inactive_tab_foreground #6099c0
 tab_bar_background #de6e7c
-wayland_titlebar_color #191919
-macos_titlebar_color #191919
 
+# The 16 terminal colors
 # normal
 color0 #191919
 color1 #3d3839

--- a/colors/base16-zenburn.conf
+++ b/colors/base16-zenburn.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base16 Zenburn
+## author:   elnawe
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Zenburn
+
 # Scheme name: base16 Zenburn
 # Scheme author: elnawe
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #383838
 foreground #dcdccc
 selection_background #6f6f6f
 selection_foreground #dcdccc
-url_color #808080
+
+# Cursor colors
 cursor #dcdccc
 cursor_text_color #383838
+
+# URL underline color when hovering with mouse
+url_color #808080
+
+# Kitty window border colors
 active_border_color #6f6f6f
 inactive_border_color #404040
+
+# OS Window titlebar colors
+wayland_titlebar_color #383838
+macos_titlebar_color #383838
+
+# Tab bar colors
 active_tab_background #383838
 active_tab_foreground #dcdccc
 inactive_tab_background #404040
 inactive_tab_foreground #808080
 tab_bar_background #404040
-wayland_titlebar_color #383838
-macos_titlebar_color #383838
 
+# The 16 terminal colors
 # normal
 color0 #383838
 color1 #dca3a3

--- a/colors/base24-brogrammer.conf
+++ b/colors/base24-brogrammer.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Brogrammer
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Brogrammer
+
 # Scheme name: base24 Brogrammer
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #131313
 foreground #c1c8d7
 selection_background #c1c8d7
 selection_foreground #131313
-url_color #d6dae4
+
+# Cursor colors
 cursor #c1c8d7
 cursor_text_color #131313
+
+# URL underline color when hovering with mouse
+url_color #d6dae4
+
+# Kitty window border colors
 active_border_color #343d50
 inactive_border_color #1f1f1f
+
+# OS Window titlebar colors
+wayland_titlebar_color #131313
+macos_titlebar_color #131313
+
+# Tab bar colors
 active_tab_background #131313
 active_tab_foreground #c1c8d7
 inactive_tab_background #1f1f1f
 inactive_tab_foreground #d6dae4
 tab_bar_background #1f1f1f
-wayland_titlebar_color #131313
-macos_titlebar_color #131313
 
+# The 16 terminal colors
 # normal
 color0 #131313
 color1 #f71118

--- a/colors/base24-chalk.conf
+++ b/colors/base24-chalk.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Chalk
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Chalk
+
 # Scheme name: base24 Chalk
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #151515
 foreground #d0d0d0
 selection_background #d0d0d0
 selection_foreground #151515
-url_color #b0b0b0
+
+# Cursor colors
 cursor #d0d0d0
 cursor_text_color #151515
+
+# URL underline color when hovering with mouse
+url_color #b0b0b0
+
+# Kitty window border colors
 active_border_color #505050
 inactive_border_color #202020
+
+# OS Window titlebar colors
+wayland_titlebar_color #151515
+macos_titlebar_color #151515
+
+# Tab bar colors
 active_tab_background #151515
 active_tab_foreground #d0d0d0
 inactive_tab_background #202020
 inactive_tab_foreground #b0b0b0
 tab_bar_background #202020
-wayland_titlebar_color #151515
-macos_titlebar_color #151515
 
+# The 16 terminal colors
 # normal
 color0 #151515
 color1 #fa859c

--- a/colors/base24-dracula.conf
+++ b/colors/base24-dracula.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Dracula
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Dracula
+
 # Scheme name: base24 Dracula
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282a36
 foreground #f8f8f2
 selection_background #f8f8f2
 selection_foreground #282a36
-url_color #9ea8c7
+
+# Cursor colors
 cursor #f8f8f2
 cursor_text_color #282a36
+
+# URL underline color when hovering with mouse
+url_color #9ea8c7
+
+# Kitty window border colors
 active_border_color #6272a4
 inactive_border_color #363447
+
+# OS Window titlebar colors
+wayland_titlebar_color #282a36
+macos_titlebar_color #282a36
+
+# Tab bar colors
 active_tab_background #282a36
 active_tab_foreground #f8f8f2
 inactive_tab_background #363447
 inactive_tab_foreground #9ea8c7
 tab_bar_background #363447
-wayland_titlebar_color #282a36
-macos_titlebar_color #282a36
 
+# The 16 terminal colors
 # normal
 color0 #282a36
 color1 #ff5555

--- a/colors/base24-espresso.conf
+++ b/colors/base24-espresso.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Espresso
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Espresso
+
 # Scheme name: base24 Espresso
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #262626
 foreground #c7c7c5
 selection_background #c7c7c5
 selection_foreground #262626
-url_color #a0a09f
+
+# Cursor colors
 cursor #c7c7c5
 cursor_text_color #262626
+
+# URL underline color when hovering with mouse
+url_color #a0a09f
+
+# Kitty window border colors
 active_border_color #797979
 inactive_border_color #343434
+
+# OS Window titlebar colors
+wayland_titlebar_color #262626
+macos_titlebar_color #262626
+
+# Tab bar colors
 active_tab_background #262626
 active_tab_foreground #c7c7c5
 inactive_tab_background #343434
 inactive_tab_foreground #a0a09f
 tab_bar_background #343434
-wayland_titlebar_color #262626
-macos_titlebar_color #262626
 
+# The 16 terminal colors
 # normal
 color0 #262626
 color1 #d25151

--- a/colors/base24-flat.conf
+++ b/colors/base24-flat.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Flat
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Flat
+
 # Scheme name: base24 Flat
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #082845
 foreground #8c939a
 selection_background #8c939a
 selection_foreground #082845
-url_color #68717b
+
+# Cursor colors
 cursor #8c939a
 cursor_text_color #082845
+
+# URL underline color when hovering with mouse
+url_color #68717b
+
+# Kitty window border colors
 active_border_color #444e5b
 inactive_border_color #1d2845
+
+# OS Window titlebar colors
+wayland_titlebar_color #082845
+macos_titlebar_color #082845
+
+# Tab bar colors
 active_tab_background #082845
 active_tab_foreground #8c939a
 inactive_tab_background #1d2845
 inactive_tab_foreground #68717b
 tab_bar_background #1d2845
-wayland_titlebar_color #082845
-macos_titlebar_color #082845
 
+# The 16 terminal colors
 # normal
 color0 #082845
 color1 #a82320

--- a/colors/base24-framer.conf
+++ b/colors/base24-framer.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Framer
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Framer
+
 # Scheme name: base24 Framer
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #111111
 foreground #a9a9a9
 selection_background #a9a9a9
 selection_foreground #111111
-url_color #868686
+
+# Cursor colors
 cursor #a9a9a9
 cursor_text_color #111111
+
+# URL underline color when hovering with mouse
+url_color #868686
+
+# Kitty window border colors
 active_border_color #636363
 inactive_border_color #141414
+
+# OS Window titlebar colors
+wayland_titlebar_color #111111
+macos_titlebar_color #111111
+
+# Tab bar colors
 active_tab_background #111111
 active_tab_foreground #a9a9a9
 inactive_tab_background #141414
 inactive_tab_foreground #868686
 tab_bar_background #141414
-wayland_titlebar_color #111111
-macos_titlebar_color #111111
 
+# The 16 terminal colors
 # normal
 color0 #111111
 color1 #ff5555

--- a/colors/base24-github.conf
+++ b/colors/base24-github.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Github
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Github
+
 # Scheme name: base24 Github
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #f4f4f4
 foreground #d8d8d8
 selection_background #d8d8d8
 selection_foreground #f4f4f4
-url_color #b2b2b2
+
+# Cursor colors
 cursor #d8d8d8
 cursor_text_color #f4f4f4
+
+# URL underline color when hovering with mouse
+url_color #b2b2b2
+
+# Kitty window border colors
 active_border_color #8c8c8c
 inactive_border_color #3e3e3e
+
+# OS Window titlebar colors
+wayland_titlebar_color #f4f4f4
+macos_titlebar_color #f4f4f4
+
+# Tab bar colors
 active_tab_background #f4f4f4
 active_tab_foreground #d8d8d8
 inactive_tab_background #3e3e3e
 inactive_tab_foreground #b2b2b2
 tab_bar_background #3e3e3e
-wayland_titlebar_color #f4f4f4
-macos_titlebar_color #f4f4f4
 
+# The 16 terminal colors
 # normal
 color0 #f4f4f4
 color1 #970b16

--- a/colors/base24-hardcore.conf
+++ b/colors/base24-hardcore.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Hardcore
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Hardcore
+
 # Scheme name: base24 Hardcore
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #111111
 foreground #a9a9a9
 selection_background #a9a9a9
 selection_foreground #111111
-url_color #868686
+
+# Cursor colors
 cursor #a9a9a9
 cursor_text_color #111111
+
+# URL underline color when hovering with mouse
+url_color #868686
+
+# Kitty window border colors
 active_border_color #636363
 inactive_border_color #141414
+
+# OS Window titlebar colors
+wayland_titlebar_color #111111
+macos_titlebar_color #111111
+
+# Tab bar colors
 active_tab_background #111111
 active_tab_foreground #a9a9a9
 inactive_tab_background #141414
 inactive_tab_foreground #868686
 tab_bar_background #141414
-wayland_titlebar_color #111111
-macos_titlebar_color #111111
 
+# The 16 terminal colors
 # normal
 color0 #111111
 color1 #ff5555

--- a/colors/base24-one-black.conf
+++ b/colors/base24-one-black.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 One Black
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    One Black
+
 # Scheme name: base24 One Black
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #000000
 foreground #abb2bf
 selection_background #abb2bf
 selection_foreground #000000
-url_color #9196a1
+
+# Cursor colors
 cursor #abb2bf
 cursor_text_color #000000
+
+# URL underline color when hovering with mouse
+url_color #9196a1
+
+# Kitty window border colors
 active_border_color #545862
 inactive_border_color #000000
+
+# OS Window titlebar colors
+wayland_titlebar_color #000000
+macos_titlebar_color #000000
+
+# Tab bar colors
 active_tab_background #000000
 active_tab_foreground #abb2bf
 inactive_tab_background #000000
 inactive_tab_foreground #9196a1
 tab_bar_background #000000
-wayland_titlebar_color #000000
-macos_titlebar_color #000000
 
+# The 16 terminal colors
 # normal
 color0 #000000
 color1 #e05561

--- a/colors/base24-one-dark.conf
+++ b/colors/base24-one-dark.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 One Dark
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    One Dark
+
 # Scheme name: base24 One Dark
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #282c34
 foreground #abb2bf
 selection_background #abb2bf
 selection_foreground #282c34
-url_color #9196a1
+
+# Cursor colors
 cursor #abb2bf
 cursor_text_color #282c34
+
+# URL underline color when hovering with mouse
+url_color #9196a1
+
+# Kitty window border colors
 active_border_color #545862
 inactive_border_color #3f4451
+
+# OS Window titlebar colors
+wayland_titlebar_color #282c34
+macos_titlebar_color #282c34
+
+# Tab bar colors
 active_tab_background #282c34
 active_tab_foreground #abb2bf
 inactive_tab_background #3f4451
 inactive_tab_foreground #9196a1
 tab_bar_background #3f4451
-wayland_titlebar_color #282c34
-macos_titlebar_color #282c34
 
+# The 16 terminal colors
 # normal
 color0 #282c34
 color1 #e05561

--- a/colors/base24-one-light.conf
+++ b/colors/base24-one-light.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 One Light
+## author:   FredHappyface (https://github.com/fredHappyface)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    One Light
+
 # Scheme name: base24 One Light
 # Scheme author: FredHappyface (https://github.com/fredHappyface)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #e7e7e9
 foreground #383a42
 selection_background #383a42
 selection_foreground #e7e7e9
-url_color #696c77
+
+# Cursor colors
 cursor #383a42
 cursor_text_color #e7e7e9
+
+# URL underline color when hovering with mouse
+url_color #696c77
+
+# Kitty window border colors
 active_border_color #a0a1a7
 inactive_border_color #dfdfe1
+
+# OS Window titlebar colors
+wayland_titlebar_color #e7e7e9
+macos_titlebar_color #e7e7e9
+
+# Tab bar colors
 active_tab_background #e7e7e9
 active_tab_foreground #383a42
 inactive_tab_background #dfdfe1
 inactive_tab_foreground #696c77
 tab_bar_background #dfdfe1
-wayland_titlebar_color #e7e7e9
-macos_titlebar_color #e7e7e9
 
+# The 16 terminal colors
 # normal
 color0 #e7e7e9
 color1 #ca1243

--- a/colors/base24-sparky.conf
+++ b/colors/base24-sparky.conf
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     base24 Sparky
+## author:   Leila Sother (https://github.com/mixcoac)
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    Sparky
+
 # Scheme name: base24 Sparky
 # Scheme author: Leila Sother (https://github.com/mixcoac)
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #072b31
 foreground #f4f5f0
 selection_background #f4f5f0
 selection_foreground #072b31
-url_color #00778b
+
+# Cursor colors
 cursor #f4f5f0
 cursor_text_color #072b31
+
+# URL underline color when hovering with mouse
+url_color #00778b
+
+# Kitty window border colors
 active_border_color #003b49
 inactive_border_color #00313c
+
+# OS Window titlebar colors
+wayland_titlebar_color #072b31
+macos_titlebar_color #072b31
+
+# Tab bar colors
 active_tab_background #072b31
 active_tab_foreground #f4f5f0
 inactive_tab_background #00313c
 inactive_tab_foreground #00778b
 tab_bar_background #00313c
-wayland_titlebar_color #072b31
-macos_titlebar_color #072b31
 
+# The 16 terminal colors
 # normal
 color0 #072b31
 color1 #ff585d

--- a/templates/base16-256-deprecated.mustache
+++ b/templates/base16-256-deprecated.mustache
@@ -1,3 +1,11 @@
+# vim:ft=kitty
+
+## name:     {{scheme-system}} {{scheme-name}}
+## author:   {{scheme-author}}
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    {{scheme-description}}
+
 # Scheme name: {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     {{scheme-system}} {{scheme-name}}
+## author:   {{scheme-author}}
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    {{scheme-description}}
+
 # Scheme name: {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #{{base00-hex}}
 foreground #{{base05-hex}}
 selection_background #{{base03-hex}}
 selection_foreground #{{base05-hex}}
-url_color #{{base04-hex}}
+
+# Cursor colors
 cursor #{{base05-hex}}
 cursor_text_color #{{base00-hex}}
+
+# URL underline color when hovering with mouse
+url_color #{{base04-hex}}
+
+# Kitty window border colors
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
+
+# OS Window titlebar colors
+wayland_titlebar_color #{{base00-hex}}
+macos_titlebar_color #{{base00-hex}}
+
+# Tab bar colors
 active_tab_background #{{base00-hex}}
 active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
 tab_bar_background #{{base01-hex}}
-wayland_titlebar_color #{{base00-hex}}
-macos_titlebar_color #{{base00-hex}}
 
+# The 16 terminal colors
 # normal
 color0 #{{base00-hex}}
 color1 #{{base08-hex}}

--- a/templates/base24-256-deprecated.mustache
+++ b/templates/base24-256-deprecated.mustache
@@ -1,3 +1,11 @@
+# vim:ft=kitty
+
+## name:     {{scheme-system}} {{scheme-name}}
+## author:   {{scheme-author}}
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    {{scheme-description}}
+
 # Scheme name: {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,24 +1,44 @@
+# vim:ft=kitty
+
+## name:     {{scheme-system}} {{scheme-name}}
+## author:   {{scheme-author}}
+## license:  MIT
+## upstream: https://github.com/tinted-theming/tinted-kitty
+## blurb:    {{scheme-description}}
+
 # Scheme name: {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-kitty)
 
+# The basic colors
 background #{{base00-hex}}
 foreground #{{base05-hex}}
 selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
-url_color #{{base04-hex}}
+
+# Cursor colors
 cursor #{{base05-hex}}
 cursor_text_color #{{base00-hex}}
+
+# URL underline color when hovering with mouse
+url_color #{{base04-hex}}
+
+# Kitty window border colors
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
+
+# OS Window titlebar colors
+wayland_titlebar_color #{{base00-hex}}
+macos_titlebar_color #{{base00-hex}}
+
+# Tab bar colors
 active_tab_background #{{base00-hex}}
 active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
 tab_bar_background #{{base01-hex}}
-wayland_titlebar_color #{{base00-hex}}
-macos_titlebar_color #{{base00-hex}}
 
+# The 16 terminal colors
 # normal
 color0 #{{base00-hex}}
 color1 #{{base08-hex}}


### PR DESCRIPTION
Kitty has a theme selector, but the themes generated by these templates weren't working, since they didn't provide the expected magic comments that kitty's theme browser was looking for.

I've updated the templates here to match the format of kitty's [theme template](https://sw.kovidgoyal.net/kitty/kittens/themes/)

I wasn't sure if I was supposed to also commit the changes to the colors or let the robot handle it, so I made that a separate commit I can drop if needed.